### PR TITLE
Update to latest engine DLL 0.5.1 to fix some merge bugs.

### DIFF
--- a/Assets/packages.config
+++ b/Assets/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.MixedReality.Unity.FrozenWorld.Engine" version="0.3.5" />
+  <package id="Microsoft.MixedReality.Unity.FrozenWorld.Engine" version="0.5.1" />
 </packages>


### PR DESCRIPTION
This engine update addresses two issues:

1) Sometimes after losing tracking and regaining, objects loaded with the scene don't return to their initial positions.

The fix is to always maintain the lower indexed fragment when merging. Since the world is loaded into fragment 1, then this preserves the coordinate space of the initial fragment.

2) Fragments don't merge even when there are multiple fragments with live WorldAnchors present. A merge doesn't happen until there is actual inter-gragment connectivity between the fragment graphs.

This was a bug in the engine's merge flag, which prevented the engine from signalling merge available until the separate graphs were connected by edges.