### PR TITLE
Add link to microsoft.github.io documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ World Locking Tools locks the entire holograph space of your application to the 
 
 World Locking Tools scale naturally with both the size and complexity of the scene. Large models, large collections of models, and multi-room environments are all handled gracefully.
 
+## Published documentation
+
+For the most up-to-date documentation, see the [World Locking Tools for Unity documentation portal](https://microsoft.github.io/MixedReality-WorldLockingTools-Unity/README.html). 
+
 ## Getting started
 
 Dive into the full documentation, beginning with the organization of the documentation itself, from the [Guides section](DocGen/Documentation/GettingStartedWithWorldLocking.md).


### PR DESCRIPTION
If someone is starting from the github repo's README.md, then they won't have full functionality of the documentation. For example, the API docs won't be generated and linked.

Putting a link at the start of the README which will direct users to the full published documentation on microsoft.github.io.