### PR TITLE
3-DOF implicit orientation computation

### DIFF
--- a/Assets/WorldLocking.Core/Scripts/Orienter.cs
+++ b/Assets/WorldLocking.Core/Scripts/Orienter.cs
@@ -153,12 +153,15 @@ namespace Microsoft.MixedReality.WorldLocking.Core
                 for (int j = i + 1; j < actives.Count; ++j)
                 {
                     WeightedRotation wrotNew = ComputeRotation(actives[i].orientable, actives[j].orientable);
-                    WeightedRotation wrot = actives[i];
-                    wrot = AverageRotation(wrot, wrotNew);
-                    actives[i] = wrot;
-                    wrot = actives[j];
-                    wrot = AverageRotation(wrot, wrotNew);
-                    actives[j] = wrot;
+                    if (wrotNew.weight > 0)
+                    {
+                        WeightedRotation wrot = actives[i];
+                        wrot = AverageRotation(wrot, wrotNew);
+                        actives[i] = wrot;
+                        wrot = actives[j];
+                        wrot = AverageRotation(wrot, wrotNew);
+                        actives[j] = wrot;
+                    }
                 }
             }
             return true;

--- a/Assets/WorldLocking.Core/Scripts/Orienter.cs
+++ b/Assets/WorldLocking.Core/Scripts/Orienter.cs
@@ -21,7 +21,7 @@ namespace Microsoft.MixedReality.WorldLocking.Core
         /// <summary>
         /// An object whose rotation needs to be computed, and the weight of its rotation.
         /// </summary>
-        private struct WeightedRotation
+        protected struct WeightedRotation
         {
             public IOrientable orientable;
             public float weight;
@@ -38,7 +38,7 @@ namespace Microsoft.MixedReality.WorldLocking.Core
         /// <summary>
         /// Orientables in the currently processing fragment.
         /// </summary>
-        private readonly List<WeightedRotation> actives = new List<WeightedRotation>();
+        protected readonly List<WeightedRotation> actives = new List<WeightedRotation>();
 
         #endregion Private members
 
@@ -146,7 +146,7 @@ namespace Microsoft.MixedReality.WorldLocking.Core
         /// Compute rotations by pairs, weighting by distance and averaging for each orientable.
         /// </summary>
         /// <returns></returns>
-        private bool ComputeRotations()
+        protected virtual bool ComputeRotations()
         {
             for (int i = 0; i < actives.Count; ++i)
             {
@@ -170,7 +170,7 @@ namespace Microsoft.MixedReality.WorldLocking.Core
         /// <param name="a"></param>
         /// <param name="b"></param>
         /// <returns></returns>
-        private WeightedRotation ComputeRotation(IOrientable a, IOrientable b)
+        protected virtual WeightedRotation ComputeRotation(IOrientable a, IOrientable b)
         {
             Vector3 lockedAtoB = b.LockedPosition - a.LockedPosition;
             lockedAtoB.y = 0.0f;
@@ -201,7 +201,7 @@ namespace Microsoft.MixedReality.WorldLocking.Core
         /// <param name="accum">The accumulator rotation.</param>
         /// <param name="add">The rotation to add in.</param>
         /// <returns>A new aggregate weighted rotation.</returns>
-        private WeightedRotation AverageRotation(WeightedRotation accum, WeightedRotation add)
+        protected WeightedRotation AverageRotation(WeightedRotation accum, WeightedRotation add)
         {
             float interp = add.weight / (accum.weight + add.weight);
 

--- a/Assets/WorldLocking.Core/Scripts/OrienterThreeBody.cs
+++ b/Assets/WorldLocking.Core/Scripts/OrienterThreeBody.cs
@@ -1,0 +1,146 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Configuration;
+using UnityEngine;
+
+
+namespace Microsoft.MixedReality.WorldLocking.Core
+{
+    public class OrienterThreeBody : Orienter
+    {
+
+        protected override bool ComputeRotations()
+        {
+            if (actives.Count <= 2)
+            {
+                return base.ComputeRotations();
+            }
+
+            for (int i = 0; i < actives.Count; ++i)
+            {
+                for (int j = i + 1; j < actives.Count; ++j)
+                {
+                    for (int k = j + 1; k < actives.Count; ++k)
+                    {
+                        WeightedRotation wrotNew = ComputeRotation(actives[i].orientable, actives[j].orientable, actives[k].orientable);
+                        WeightedRotation wrot = actives[i];
+                        wrot = AverageRotation(wrot, wrotNew);
+                        actives[i] = wrot;
+                        wrot = actives[j];
+                        wrot = AverageRotation(wrot, wrotNew);
+                        actives[j] = wrot;
+                        wrot = actives[k];
+                        wrot = AverageRotation(wrot, wrotNew);
+                        actives[k] = wrot;
+                    }
+                }
+            }
+            return true;
+        }
+
+        protected override WeightedRotation ComputeRotation(IOrientable a, IOrientable b)
+        {
+            Vector3 lockedAtoB = b.LockedPosition - a.LockedPosition;
+            lockedAtoB.Normalize();
+
+            Vector3 virtualAtoB = b.ModelPosition - a.ModelPosition;
+            virtualAtoB.Normalize();
+
+            Quaternion rotVirtualFromLocked = Quaternion.FromToRotation(virtualAtoB, lockedAtoB);
+            rotVirtualFromLocked.Normalize();
+
+            float weight = (a.ModelPosition - b.ModelPosition).sqrMagnitude;
+            float minDistSq = 0.0f;
+            weight = weight > minDistSq ? 1.0f / weight : 1.0f;
+
+            return new WeightedRotation()
+            {
+                orientable = null,
+                rotation = rotVirtualFromLocked,
+                weight = weight
+            };
+        }
+
+        private WeightedRotation ComputeRotation(IOrientable a, IOrientable b, IOrientable c)
+        {
+            Vector3 lockedA = a.LockedPosition;
+            Vector3 lockedB = b.LockedPosition;
+            Vector3 lockedC = c.LockedPosition;
+
+            Vector3 lockedBtoA = lockedA - lockedB;
+            Vector3 lockedBtoC = lockedC - lockedB;
+
+            float weight = ComputeWeight(lockedBtoA, lockedBtoC);
+
+            Quaternion rotVirtualFromLocked = Quaternion.identity;
+
+            if (weight > 0)
+            {
+                Vector3 virtualBtoA = a.ModelPosition - b.ModelPosition;
+                Vector3 virtualBtoC = c.ModelPosition - b.ModelPosition;
+
+                Quaternion rotationFirst = Quaternion.FromToRotation(virtualBtoA, lockedBtoA);
+
+                virtualBtoC = rotationFirst * virtualBtoC;
+
+                Vector3 dir = lockedBtoA;
+                dir.Normalize();
+                Vector3 up = Vector3.Cross(lockedBtoC, dir);
+                up.Normalize();
+                Vector3 right = Vector3.Cross(dir, up);
+
+                float sinRads = Vector3.Dot(virtualBtoC, up);
+                float cosRads = Vector3.Dot(virtualBtoC, right);
+
+                float rotRads = Mathf.Atan2(sinRads, cosRads);
+
+                Quaternion rotationSecond = Quaternion.AngleAxis(Mathf.Rad2Deg * rotRads, dir);
+
+                rotVirtualFromLocked = rotationSecond * rotationFirst;
+
+                rotVirtualFromLocked.Normalize();
+            }
+
+            return new WeightedRotation()
+            {
+                orientable = null,
+                rotation = rotVirtualFromLocked,
+                weight = weight
+            };
+
+        }
+        private float ComputeWeight(Vector3 lockedBtoA, Vector3 lockedBtoC)
+        {
+            float weight = 1.0f;
+
+            float minDist = 0.01f; // a centimeter, really should be much further apart to be provide satisfactory results (like 10s of meters).
+            if (lockedBtoA.magnitude < minDist || lockedBtoC.magnitude < minDist)
+            {
+                weight = 0.0f;
+            }
+            if (weight > 0)
+            {
+                float dist = Mathf.Max(lockedBtoA.magnitude, lockedBtoC.magnitude);
+                weight *= 1.0f / dist;
+            }
+            if (weight > 0)
+            {
+                // Check absolute value of normalized dot product. If too aligned (near 1) then computed transforms will be unstable.
+                // Note degenerate cases of zero length difference vectors has been filtered out above.
+                float maxAbsDot = 0.985f; // about 10 degrees
+                float absDot = Math.Abs(Vector3.Dot(lockedBtoA.normalized, lockedBtoC.normalized));
+                if (absDot > maxAbsDot)
+                {
+                    weight = 0.0f;
+                }
+                else
+                {
+                    weight *= 1.0f - absDot;
+                }
+
+            }
+            return weight;
+        }
+    }
+}

--- a/Assets/WorldLocking.Core/Scripts/OrienterThreeBody.cs.meta
+++ b/Assets/WorldLocking.Core/Scripts/OrienterThreeBody.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 677c11a90b63d37498915986b5a9439c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/WorldLocking.Examples/Scenes/SpacePin.unity
+++ b/Assets/WorldLocking.Examples/Scenes/SpacePin.unity
@@ -538,7 +538,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5b54ea26464070b499d1c6f072d7c6a0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  orienter: {fileID: 464047946}
+  orienter: {fileID: 802402001}
   prefab_FeelerRay: {fileID: 1335525745713039694, guid: 498c830c5e5604e44b3788a7f47a4392,
     type: 3}
 --- !u!1 &251339567
@@ -750,7 +750,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 305681508}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -6, y: 0, z: 0}
+  m_LocalPosition: {x: -4, y: 0, z: 0}
   m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
   m_Children: []
   m_Father: {fileID: 105386729}
@@ -1114,7 +1114,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 405542362}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -8}
+  m_LocalPosition: {x: 0, y: 0, z: -4}
   m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
   m_Children: []
   m_Father: {fileID: 105386729}
@@ -2137,7 +2137,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 738417653}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 10, y: 0, z: 0}
+  m_LocalPosition: {x: 5, y: 0, z: 0}
   m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
   m_Children: []
   m_Father: {fileID: 105386729}
@@ -2230,7 +2230,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 738951414}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -6, y: 0, z: 0}
+  m_LocalPosition: {x: -4, y: 0, z: 0}
   m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
   m_Children: []
   m_Father: {fileID: 1714104116}
@@ -2320,7 +2320,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5b54ea26464070b499d1c6f072d7c6a0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  orienter: {fileID: 464047946}
+  orienter: {fileID: 802402001}
   prefab_FeelerRay: {fileID: 1335525745713039694, guid: 498c830c5e5604e44b3788a7f47a4392,
     type: 3}
 --- !u!1 &785279988
@@ -2423,6 +2423,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 802402000}
+  - component: {fileID: 802402001}
   m_Layer: 0
   m_Name: Content
   m_TagString: Untagged
@@ -2437,7 +2438,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 802401999}
-  m_LocalRotation: {x: 0, y: 0.2588191, z: 0, w: 0.9659258}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -2445,7 +2446,19 @@ Transform:
   - {fileID: 1462942726}
   m_Father: {fileID: 0}
   m_RootOrder: 5
-  m_LocalEulerAnglesHint: {x: 0, y: 30, z: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &802402001
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 802401999}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 677c11a90b63d37498915986b5a9439c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &860117963
 GameObject:
   m_ObjectHideFlags: 0
@@ -2701,7 +2714,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 947699059}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.1, y: 0, z: -8}
+  m_LocalPosition: {x: 0.1, y: 0, z: -4}
   m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
   m_Children: []
   m_Father: {fileID: 1714104116}
@@ -2791,7 +2804,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5b54ea26464070b499d1c6f072d7c6a0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  orienter: {fileID: 464047946}
+  orienter: {fileID: 802402001}
   prefab_FeelerRay: {fileID: 1335525745713039694, guid: 498c830c5e5604e44b3788a7f47a4392,
     type: 3}
 --- !u!1 &970621988
@@ -3278,7 +3291,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1138103469}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 10, y: 0, z: 0}
+  m_LocalPosition: {x: 5, y: 0, z: 0}
   m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
   m_Children: []
   m_Father: {fileID: 1714104116}
@@ -3368,7 +3381,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5b54ea26464070b499d1c6f072d7c6a0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  orienter: {fileID: 464047946}
+  orienter: {fileID: 802402001}
   prefab_FeelerRay: {fileID: 1335525745713039694, guid: 498c830c5e5604e44b3788a7f47a4392,
     type: 3}
 --- !u!1 &1201825122
@@ -4725,7 +4738,7 @@ Camera:
   m_GameObject: {fileID: 1602340178}
   m_Enabled: 1
   serializedVersion: 2
-  m_ClearFlags: 2
+  m_ClearFlags: 1
   m_BackGroundColor: {r: 0, g: 0, b: 0, a: 1}
   m_projectionMatrixMode: 1
   m_SensorSize: {x: 36, y: 24}
@@ -5402,6 +5415,21 @@ PrefabInstance:
       propertyPath: shared.linkageSettings.CameraParent
       value: 
       objectReference: {fileID: 1552178807}
+    - target: {fileID: 114794997547214612, guid: f0777d53f35d4cb42827b5c3bdf227bd,
+        type: 3}
+      propertyPath: shared.settings.useDefaults
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 114794997547214612, guid: f0777d53f35d4cb42827b5c3bdf227bd,
+        type: 3}
+      propertyPath: shared.settings.AutoLoad
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 114794997547214612, guid: f0777d53f35d4cb42827b5c3bdf227bd,
+        type: 3}
+      propertyPath: shared.settings.AutoSave
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 4133740187393454, guid: f0777d53f35d4cb42827b5c3bdf227bd, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0

--- a/Assets/WorldLocking.Examples/Scenes/SpacePin.unity
+++ b/Assets/WorldLocking.Examples/Scenes/SpacePin.unity
@@ -538,7 +538,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5b54ea26464070b499d1c6f072d7c6a0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  orienter: {fileID: 802402001}
+  orienter: {fileID: 464047946}
   prefab_FeelerRay: {fileID: 1335525745713039694, guid: 498c830c5e5604e44b3788a7f47a4392,
     type: 3}
 --- !u!1 &251339567
@@ -750,7 +750,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 305681508}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -4, y: 0, z: 0}
+  m_LocalPosition: {x: -6, y: 0, z: 0}
   m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
   m_Children: []
   m_Father: {fileID: 105386729}
@@ -1114,7 +1114,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 405542362}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -4}
+  m_LocalPosition: {x: 0, y: 0, z: -8}
   m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
   m_Children: []
   m_Father: {fileID: 105386729}
@@ -2137,7 +2137,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 738417653}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 5, y: 0, z: 0}
+  m_LocalPosition: {x: 10, y: 0, z: 0}
   m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
   m_Children: []
   m_Father: {fileID: 105386729}
@@ -2230,7 +2230,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 738951414}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -4, y: 0, z: 0}
+  m_LocalPosition: {x: -6, y: 0, z: 0}
   m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
   m_Children: []
   m_Father: {fileID: 1714104116}
@@ -2320,7 +2320,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5b54ea26464070b499d1c6f072d7c6a0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  orienter: {fileID: 802402001}
+  orienter: {fileID: 464047946}
   prefab_FeelerRay: {fileID: 1335525745713039694, guid: 498c830c5e5604e44b3788a7f47a4392,
     type: 3}
 --- !u!1 &785279988
@@ -2423,7 +2423,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 802402000}
-  - component: {fileID: 802402001}
   m_Layer: 0
   m_Name: Content
   m_TagString: Untagged
@@ -2438,7 +2437,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 802401999}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: 0, y: 0.2588191, z: 0, w: 0.9659258}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -2446,19 +2445,7 @@ Transform:
   - {fileID: 1462942726}
   m_Father: {fileID: 0}
   m_RootOrder: 5
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &802402001
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 802401999}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 677c11a90b63d37498915986b5a9439c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_LocalEulerAnglesHint: {x: 0, y: 30, z: 0}
 --- !u!1 &860117963
 GameObject:
   m_ObjectHideFlags: 0
@@ -2714,7 +2701,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 947699059}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.1, y: 0, z: -4}
+  m_LocalPosition: {x: 0.1, y: 0, z: -8}
   m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
   m_Children: []
   m_Father: {fileID: 1714104116}
@@ -2804,7 +2791,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5b54ea26464070b499d1c6f072d7c6a0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  orienter: {fileID: 802402001}
+  orienter: {fileID: 464047946}
   prefab_FeelerRay: {fileID: 1335525745713039694, guid: 498c830c5e5604e44b3788a7f47a4392,
     type: 3}
 --- !u!1 &970621988
@@ -3291,7 +3278,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1138103469}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 5, y: 0, z: 0}
+  m_LocalPosition: {x: 10, y: 0, z: 0}
   m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
   m_Children: []
   m_Father: {fileID: 1714104116}
@@ -3381,7 +3368,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5b54ea26464070b499d1c6f072d7c6a0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  orienter: {fileID: 802402001}
+  orienter: {fileID: 464047946}
   prefab_FeelerRay: {fileID: 1335525745713039694, guid: 498c830c5e5604e44b3788a7f47a4392,
     type: 3}
 --- !u!1 &1201825122
@@ -4738,7 +4725,7 @@ Camera:
   m_GameObject: {fileID: 1602340178}
   m_Enabled: 1
   serializedVersion: 2
-  m_ClearFlags: 1
+  m_ClearFlags: 2
   m_BackGroundColor: {r: 0, g: 0, b: 0, a: 1}
   m_projectionMatrixMode: 1
   m_SensorSize: {x: 36, y: 24}
@@ -5415,21 +5402,6 @@ PrefabInstance:
       propertyPath: shared.linkageSettings.CameraParent
       value: 
       objectReference: {fileID: 1552178807}
-    - target: {fileID: 114794997547214612, guid: f0777d53f35d4cb42827b5c3bdf227bd,
-        type: 3}
-      propertyPath: shared.settings.useDefaults
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 114794997547214612, guid: f0777d53f35d4cb42827b5c3bdf227bd,
-        type: 3}
-      propertyPath: shared.settings.AutoLoad
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 114794997547214612, guid: f0777d53f35d4cb42827b5c3bdf227bd,
-        type: 3}
-      propertyPath: shared.settings.AutoSave
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 4133740187393454, guid: f0777d53f35d4cb42827b5c3bdf227bd, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0


### PR DESCRIPTION
*Capability:*

The existing Orienter class computes an implied orientation based on the positions of the SpacePinOrientables in the physical world. As a simplifying assumption, the orientation is limited to yaw (rotation about the gravity vector/Y-axis). This is mostly simplifying for the application using the feature. Most applications assume that the Y-axis remains aligned with the gravity vector (e.g. when placing a billboard), and would be inconvenienced by WLT rotating space to break that assumption.

The new IOrienter class, OrienterThreeBody, does away with that simplification and computes a full 3-DOF rotation (rotation about all 3 axes). In particular, for slight corrections to pitch and roll to align a model with its physical counterpart, the negatives of the Y-axis no longer aligned with the physical gravity vector are minimal, while the positives of fully aligning modeling space with physical space are obvious.

*Code changes:*

A new capability is offered, via a new derived script. No existing behavior is modified. 

Existing code is modified only in the form of changing some functions of the Orienter class to virtual. While the same results could have been achieved by deriving the new class OrienterThreeBody from IOrienter and leaving Orienter unchanged, it would have involved a lot of cut&paste code.

Further, by deriving from Orienter (rather than IOrienter), the differences between the two IOrienter types is much clearer (and, as seen, minimal).