### PR TITLE
Allow explicit rotation setting on first auto-oriented space pin.

### DIFF
--- a/Assets/WorldLocking.Core/Scripts/IOrienter.cs
+++ b/Assets/WorldLocking.Core/Scripts/IOrienter.cs
@@ -22,9 +22,19 @@ namespace Microsoft.MixedReality.WorldLocking.Core
         Vector3 ModelPosition { get; }
 
         /// <summary>
+        /// The orientation of the object in Modeling space.
+        /// </summary>
+        Quaternion ModelRotation { get; }
+
+        /// <summary>
         /// The desired position of the object in world locked space.
         /// </summary>
         Vector3 LockedPosition { get; }
+
+        /// <summary>
+        /// The desired rotation of the object in world locked space.
+        /// </summary>
+        Quaternion LockedRotation { get; }
 
         /// <summary>
         /// Accept a rotation computed externally (by an <see cref="IOrienter"/>).

--- a/Assets/WorldLocking.Core/Scripts/Orienter.cs
+++ b/Assets/WorldLocking.Core/Scripts/Orienter.cs
@@ -134,6 +134,9 @@ namespace Microsoft.MixedReality.WorldLocking.Core
                         {
                             orientable = orientables[i],
                             weight = 0.0f,
+                            /// Default rotation is current rotation. The inverse of the model rotation will
+                            /// cancel out the model rotation when the coordinate system rotation is computed, 
+                            /// using the unmodified locked rotation.
                             rotation = orientables[i].LockedRotation * Quaternion.Inverse(orientables[i].ModelRotation)
                         }
                     );

--- a/Assets/WorldLocking.Core/Scripts/Orienter.cs
+++ b/Assets/WorldLocking.Core/Scripts/Orienter.cs
@@ -134,7 +134,7 @@ namespace Microsoft.MixedReality.WorldLocking.Core
                         {
                             orientable = orientables[i],
                             weight = 0.0f,
-                            rotation = Quaternion.identity
+                            rotation = orientables[i].LockedRotation * Quaternion.Inverse(orientables[i].ModelRotation)
                         }
                     );
                 }

--- a/Assets/WorldLocking.Core/Scripts/SpacePin.cs
+++ b/Assets/WorldLocking.Core/Scripts/SpacePin.cs
@@ -87,7 +87,7 @@ namespace Microsoft.MixedReality.WorldLocking.Core
         /// <summary>
         /// First of the pair of poses submitted to alignment manager for alignment.
         /// </summary>
-        public virtual Pose ModelingPose
+        public Pose ModelingPose
         {
             get { return initialPose; }
         }

--- a/Assets/WorldLocking.Core/Scripts/SpacePinOrientable.cs
+++ b/Assets/WorldLocking.Core/Scripts/SpacePinOrientable.cs
@@ -82,7 +82,6 @@ namespace Microsoft.MixedReality.WorldLocking.Core
         /// <param name="lockedRotation">The new world locked rotation to adopt.</param>
         public void PushRotation(IAlignmentManager mgr, Quaternion lockedRotation)
         {
-            // mafinc dehack
             /// Append the modeling pose rotation. This will cancel out when computing the 
             /// pinnedFromLocked transform, so that the computed rotation gets applied as is.
             LockedPose = new Pose(LockedPose.position, lockedRotation * ModelingPose.rotation);

--- a/Assets/WorldLocking.Core/Scripts/SpacePinOrientable.cs
+++ b/Assets/WorldLocking.Core/Scripts/SpacePinOrientable.cs
@@ -63,15 +63,17 @@ namespace Microsoft.MixedReality.WorldLocking.Core
             }
         }
 
-        /// <summary>
-        /// The position in modeling space.
-        /// </summary>
+        /// <inheritdocs />
         public Vector3 ModelPosition { get { return ModelingPose.position; } }
 
-        /// <summary>
-        /// The position in locked space.
-        /// </summary>
+        /// <inheritdocs />
+        public Quaternion ModelRotation { get { return ModelingPose.rotation; } }
+
+        /// <inheritdocs />
         public Vector3 LockedPosition { get { return LockedPose.position; } }
+
+        /// <inheritdocs />
+        public Quaternion LockedRotation { get { return LockedPose.rotation; } }
 
         /// <summary>
         /// Accept the rotation as computed by the IOrienter.
@@ -80,7 +82,10 @@ namespace Microsoft.MixedReality.WorldLocking.Core
         /// <param name="lockedRotation">The new world locked rotation to adopt.</param>
         public void PushRotation(IAlignmentManager mgr, Quaternion lockedRotation)
         {
-            LockedPose = new Pose(LockedPose.position, lockedRotation);
+            // mafinc dehack
+            /// Append the modeling pose rotation. This will cancel out when computing the 
+            /// pinnedFromLocked transform, so that the computed rotation gets applied as is.
+            LockedPose = new Pose(LockedPose.position, lockedRotation * ModelingPose.rotation);
             PushAlignmentData(mgr);
         }
 
@@ -93,7 +98,9 @@ namespace Microsoft.MixedReality.WorldLocking.Core
         /// <param name="frozenPosition">Position in frozen space.</param>
         public void SetFrozenPosition(Vector3 frozenPosition)
         {
-            SetFrozenPose(new Pose(frozenPosition, Quaternion.identity));
+            WorldLockingManager wltMgr = WorldLockingManager.GetInstance();
+            Vector3 lockedPosition = wltMgr.LockedFromFrozen.Multiply(frozenPosition);
+            SetLockedPose(new Pose(lockedPosition, LockedRotation));
         }
 
         /// <summary>
@@ -102,7 +109,9 @@ namespace Microsoft.MixedReality.WorldLocking.Core
         /// <param name="spongyPosition">Position in spongyt space.</param>
         public void SetSpongyPosition(Vector3 spongyPosition)
         {
-            SetSpongyPose(new Pose(spongyPosition, Quaternion.identity));
+            WorldLockingManager wltMgr = WorldLockingManager.GetInstance();
+            Vector3 lockedPosition = wltMgr.LockedFromSpongy.Multiply(spongyPosition);
+            SetLockedPose(new Pose(lockedPosition, LockedRotation));
         }
 
         /// <summary>
@@ -111,26 +120,12 @@ namespace Microsoft.MixedReality.WorldLocking.Core
         /// <param name="lockedPosition">Position in locked space.</param>
         public void SetLockedPosition(Vector3 lockedPosition)
         {
-            SetLockedPose(new Pose(lockedPosition, Quaternion.identity));
+            SetLockedPose(new Pose(lockedPosition, LockedRotation));
         }
 
         #endregion Public APIs added
 
         #region SpacePin overrides
-
-        /// <summary>
-        /// The modeling (virtual) space pose for this pin.
-        /// </summary>
-        /// <remarks>
-        /// The rotation here is nulled because an explicit target rotation is computed which includes the initial rotation.
-        /// Also having the initial rotation input as part of the modeling pose would apply that rotation twice.
-        /// It would also be possible to leave this rotation as is and factor it out of the computed rotation with
-        /// some additional math.
-        /// </remarks>
-        public override Pose ModelingPose
-        {
-            get { return new Pose(InitialPose.position, Quaternion.identity); }
-        }
 
         /// <summary>
         /// Adopt the Inspector set Orienter as the interface iorienter.

--- a/Assets/WorldLocking.Core/Scripts/WorldLockingManager.cs
+++ b/Assets/WorldLocking.Core/Scripts/WorldLockingManager.cs
@@ -497,8 +497,7 @@ namespace Microsoft.MixedReality.WorldLocking.Core
 
                 SpongyFromCamera = Plugin.GetSpongyHead();
 
-                Pose playspaceFromSpongy = CameraParent.GetLocalPose();
-                Pose lockedHeadPose = LockedFromPlayspace.Multiply(playspaceFromSpongy.Multiply(SpongyFromCamera));
+                Pose lockedHeadPose = LockedFromPlayspace.Multiply(PlayspaceFromSpongy.Multiply(SpongyFromCamera));
                 alignmentManager.ComputePinnedPose(lockedHeadPose);
                 PinnedFromLocked = alignmentManager.PinnedFromLocked;
             }

--- a/Assets/WorldLocking.Examples/Scenes/SpacePin3Body.unity
+++ b/Assets/WorldLocking.Examples/Scenes/SpacePin3Body.unity
@@ -2394,7 +2394,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 802401999}
-  m_LocalRotation: {x: 0, y: 0.2588191, z: 0, w: 0.9659258}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -2402,7 +2402,7 @@ Transform:
   - {fileID: 1462942726}
   m_Father: {fileID: 0}
   m_RootOrder: 5
-  m_LocalEulerAnglesHint: {x: 0, y: 30, z: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &860117963
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/WorldLocking.Examples/Scripts/SpacePinOrientableManipulation.cs
+++ b/Assets/WorldLocking.Examples/Scripts/SpacePinOrientableManipulation.cs
@@ -24,6 +24,20 @@ namespace Microsoft.MixedReality.WorldLocking.Examples
         /// Proxy renderable to show axis alignment during manipulations.
         /// </summary>
         public GameObject Prefab_FeelerRay { get { return prefab_FeelerRay; } set { prefab_FeelerRay = value; } }
+
+        [SerializeField]
+        [Tooltip("Whether to show the MRTK rotation gizmos.")]
+        private bool allowRotation = true;
+
+        /// <summary>
+        /// Whether to show the MRTK rotation gizmos.
+        /// </summary>
+        /// <remarks>
+        /// Rotating the SpacePinOrientableManipulation object only has any effect when the first
+        /// pin is manipulated. Once the second object is manipulated, and ever after, the orientation
+        /// is implied by the alignment of the pin objects, and actual orientation of the objects is ignored.
+        /// </remarks>
+        public bool AllowRotation { get { return allowRotation; } set { allowRotation = value; } }
         #endregion Inspector fields
 
         #region Internal fields
@@ -45,7 +59,7 @@ namespace Microsoft.MixedReality.WorldLocking.Examples
             base.Start();
 
             pinManipulator = new PinManipulator(transform, Prefab_FeelerRay, OnFinishManipulation);
-            pinManipulator.UserOriented = false;
+            pinManipulator.UserOriented = AllowRotation;
             pinManipulator.Startup();
         }
 
@@ -73,7 +87,7 @@ namespace Microsoft.MixedReality.WorldLocking.Examples
         /// </summary>
         private void OnFinishManipulation()
         {
-            SetFrozenPosition(transform.GetGlobalPose().position);
+            SetFrozenPose(transform.GetGlobalPose());
         }
     }
 }


### PR DESCRIPTION
The SpacePinOrientation family of space pins computes the implicit orientation from the positions of the active space pins.

That requires at least two space pins to be active, in order for there to be an implied orientation.

Previously, when only a single pin had its position set, the system would use an identity rotation until the required second pin was set.

With this addition, if there is an explicit rotation set on the first pin, that will be used until a second pin's position provides an implied rotation.

This involved a small refactor which seems an improvement on its own (although doesn't provide functional change).