### PR TITLE
Enable serialization of Orienter set from script

### DIFF
--- a/Assets/WorldLocking.Core/Scripts/SpacePinOrientable.cs
+++ b/Assets/WorldLocking.Core/Scripts/SpacePinOrientable.cs
@@ -246,6 +246,11 @@ namespace Microsoft.MixedReality.WorldLocking.Core
         public void SetOrienter(IOrienter iorienter)
         {
             this.iorienter = iorienter;
+            // If of an appropriate type, assign to the serialized orienter field as well.
+            if (iorienter is Orienter)
+            {
+                orienter = iorienter as Orienter;
+            }
         }
         #endregion IOrienter access
     }

--- a/Assets/packages.config
+++ b/Assets/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.MixedReality.Unity.FrozenWorld.Engine" version="0.5.2" />
+  <package id="Microsoft.MixedReality.Unity.FrozenWorld.Engine" version="0.5.1" />
 </packages>

--- a/Assets/packages.config
+++ b/Assets/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.MixedReality.Unity.FrozenWorld.Engine" version="0.5.1" />
+  <package id="Microsoft.MixedReality.Unity.FrozenWorld.Engine" version="0.5.2" />
 </packages>


### PR DESCRIPTION
If iorienter set from script is of appropriate type (dervies from Orienter), also set it to the serialized orienter field. This is specifically for setting the iorienter from script in Editor, to allow the edited SpacePinOrientable to have its orienter serialized.

This PR also upgrades to the latest FW DLL, which includes a good fix for an obscure condition.

Fixes #47 