### PR TITLE
Space pin position by bounds

### DIFF
--- a/Assets/WorldLocking.Examples/Scripts/SpacePinManipulation.cs
+++ b/Assets/WorldLocking.Examples/Scripts/SpacePinManipulation.cs
@@ -78,7 +78,7 @@ namespace Microsoft.MixedReality.WorldLocking.Examples
         /// </summary>
         private void OnFinishManipulation()
         {
-            SetFrozenPose(transform.GetGlobalPose());
+            SetFrozenPose(ExtractModelPose());
         }
 
         #endregion Manipulation callback

--- a/Assets/WorldLocking.Examples/Scripts/SpacePinOrientableManipulation.cs
+++ b/Assets/WorldLocking.Examples/Scripts/SpacePinOrientableManipulation.cs
@@ -87,7 +87,7 @@ namespace Microsoft.MixedReality.WorldLocking.Examples
         /// </summary>
         private void OnFinishManipulation()
         {
-            SetFrozenPose(transform.GetGlobalPose());
+            SetFrozenPose(ExtractModelPose());
         }
     }
 }

--- a/Assets/WorldLocking.Tests/Core/Scripts/AlignmentManagerTest.cs
+++ b/Assets/WorldLocking.Tests/Core/Scripts/AlignmentManagerTest.cs
@@ -203,6 +203,41 @@ namespace Microsoft.MixedReality.WorldLocking.Tests.Core
         }
 
         [UnityTest]
+        public IEnumerator AlignmentManagerTestByBounds()
+        {
+            var rig = loadHelper.LoadBasicSceneRig();
+
+            var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            cube.transform.position = new Vector3(3.0f, 4.0f, 5.0f);
+
+            var spacePin = cube.AddComponent<SpacePin>();
+
+            yield return null;
+
+            Assert.AreEqual(cube.transform.position, spacePin.ModelingPoseGlobal.position);
+
+            spacePin.ModelPositionSource = SpacePin.ModelPositionSourceEnum.RendererBounds;
+            spacePin.ResetModelingPose();
+
+            var renderer = cube.GetComponent<Renderer>();
+            Assert.NotNull(renderer);
+            Assert.AreEqual(renderer.bounds.center, spacePin.ModelingPoseGlobal.position);
+
+            spacePin.ModelPositionSource = SpacePin.ModelPositionSourceEnum.ColliderBounds;
+            spacePin.ResetModelingPose();
+
+            var collider = cube.GetComponent<BoxCollider>();
+            Assert.NotNull(collider);
+            Assert.AreEqual(collider.bounds.center, spacePin.ModelingPoseGlobal.position);
+
+            collider.center = -cube.transform.position;
+            spacePin.ResetModelingPose();
+            Assert.AreEqual(Vector3.zero, spacePin.ModelingPoseGlobal.position);
+
+            yield return null;
+        }
+
+        [UnityTest]
         public IEnumerator AlignmentManagerTestBasic()
         {
             var rig = loadHelper.LoadBasicSceneRig();

--- a/Assets/WorldLocking.Tools/Scripts/AdjusterFixed.cs
+++ b/Assets/WorldLocking.Tools/Scripts/AdjusterFixed.cs
@@ -13,6 +13,7 @@ namespace Microsoft.MixedReality.WorldLocking.Tools
     /// </summary>
     /// <remarks>
     /// For dynamic objects, use <see cref="AdjusterMoving"/>.
+    /// 
     /// This component is appropriate for inheriting from, to let it take care of
     /// lifetime management and book-keeping, then just override <see cref="HandleAdjustLocation(Pose)"/>
     /// and/or <see cref="HandleAdjustState(AttachmentPointStateType)"/> with actions more suitable

--- a/Assets/WorldLocking.Tools/Scripts/AdjusterFixed.cs
+++ b/Assets/WorldLocking.Tools/Scripts/AdjusterFixed.cs
@@ -12,17 +12,29 @@ namespace Microsoft.MixedReality.WorldLocking.Tools
     /// Component to handle frozen world adjustments for fixed (stationary) objects.
     /// </summary>
     /// <remarks>
-    /// For dynamic objects, use <see cref="AdjusterMoving"/>
+    /// For dynamic objects, use <see cref="AdjusterMoving"/>.
+    /// This component is appropriate for inheriting from, to let it take care of
+    /// lifetime management and book-keeping, then just override <see cref="HandleAdjustLocation(Pose)"/>
+    /// and/or <see cref="HandleAdjustState(AttachmentPointStateType)"/> with actions more suitable
+    /// for your application.
     /// </remarks>
     public class AdjusterFixed : AdjusterBase
     {
+        /// <summary>
+        /// The attachment point manager interface which this component subscribes to.
+        /// </summary>
         protected IAttachmentPointManager Manager { get { return WorldLockingManager.GetInstance().AttachmentPointManager; } }
 
+        /// <summary>
+        /// The attachment point which this component wraps.
+        /// </summary>
         protected IAttachmentPoint AttachmentPoint { get; private set; }
 
+        /// <summary>
+        /// Ask the manager for an attachment point, passing delegates for update
+        /// </summary>
         private void Start()
         {
-            // Ask the manager for an attachment point, passing delegates for update
             AttachmentPoint = Manager.CreateAttachmentPoint(gameObject.transform.position, null,
                 HandleAdjustLocation,   // Handle adjustments to position
                 HandleAdjustState  // Handle connectedness of fragment
@@ -30,14 +42,35 @@ namespace Microsoft.MixedReality.WorldLocking.Tools
             AttachmentPoint.Name = string.Format($"{gameObject.name}=>{AttachmentPoint.Name}");
         }
 
+        /// <summary>
+        /// Let the manager know the attachment point is freed.   
+        /// </summary>
         private void OnDestroy()
         {
-            // Let the manager know the attachment point is freed.   
             Manager.ReleaseAttachmentPoint(AttachmentPoint);
             AttachmentPoint = null;
         }
 
-        // mafinc - should have attach point as parameter?
+        /// <summary>
+        /// For infrequent moves under script control, UpdatePosition notifies the system that the
+        /// object has relocated. It should be called after any scripted movement of the object
+        /// (but **not** after movement triggered by WLT, such as in <see cref="HandleAdjustLocation(Pose)"/>).
+        /// </summary>
+        public void UpdatePosition()
+        {
+            if (AttachmentPoint != null)
+            {
+                Manager.MoveAttachmentPoint(AttachmentPoint, gameObject.transform.position);
+            }
+        }
+
+        /// <summary>
+        /// Handle a pose adjustment due to a refit operation.
+        /// </summary>
+        /// <param name="adjustment">The pose adjustment to apply/</param>
+        /// <remarks>
+        /// This simple implementation folds the adjustment into the current pose.
+        /// </remarks>
         protected virtual void HandleAdjustLocation(Pose adjustment)
         {
             Pose pose = gameObject.transform.GetGlobalPose();
@@ -45,6 +78,21 @@ namespace Microsoft.MixedReality.WorldLocking.Tools
             gameObject.transform.SetGlobalPose(pose);
         }
 
+        /// <summary>
+        /// Handle a change in associated fragment state.
+        /// </summary>
+        /// <param name="state">The new state.</param>
+        /// <remarks>
+        /// The only state under which the visual location can be regarded as reliable
+        /// is the Normal state.
+        /// This simple implementation disables the object tree when its location is unreliable,
+        /// and enables it when its location is reliable.
+        /// Actual appropriate behavior is highly application dependent. Some questions to ask:
+        /// * Is there a more appropriate way to hide the object (e.g. move it far away)?
+        /// * Should the update pause, or just stop rendering? (Disabling pauses update **and** render).
+        /// * Is it better to hide the object, or to display it in alternate form?
+        /// * Etc.
+        /// </remarks>
         protected virtual void HandleAdjustState(AttachmentPointStateType state)
         {
             bool visible = state == AttachmentPointStateType.Normal;

--- a/Assets/WorldLocking.Tools/Scripts/AdjusterMoving.cs
+++ b/Assets/WorldLocking.Tools/Scripts/AdjusterMoving.cs
@@ -10,16 +10,21 @@ namespace Microsoft.MixedReality.WorldLocking.Tools
     /// Component to handle frozen world adjustments for dynamic (moving) objects.
     /// </summary>
     /// <remarks>
-    /// For stationary objects, use <see cref="AdjusterFixed"/>
+    /// For stationary objects, use <see cref="AdjusterFixed"/>.
+    /// This component uses the Unity Update pass to keep the World Locking Tools system
+    /// apprised of the target object's position. While that operation is cheap, even
+    /// just the cost of an additional Update() is best avoided for stationary objects.
+    /// If the object moves very infrequently under script control, consider using an <see cref="AdjusterFixed"/>,
+    /// and notifying it after moves with <see cref="AdjusterFixed.UpdatePosition"/>.
     /// </remarks>
     public class AdjusterMoving : AdjusterFixed
     {
+        /// <summary>
+        /// Notify the system each frame of current position.
+        /// </summary>
         private void Update()
         {
-            if (AttachmentPoint != null)
-            {
-                Manager.MoveAttachmentPoint(AttachmentPoint, gameObject.transform.position);
-            }
+            UpdatePosition();
         }
     }
 }

--- a/Assets/WorldLocking.Tools/Scripts/AdjusterMoving.cs
+++ b/Assets/WorldLocking.Tools/Scripts/AdjusterMoving.cs
@@ -11,9 +11,11 @@ namespace Microsoft.MixedReality.WorldLocking.Tools
     /// </summary>
     /// <remarks>
     /// For stationary objects, use <see cref="AdjusterFixed"/>.
+    /// 
     /// This component uses the Unity Update pass to keep the World Locking Tools system
     /// apprised of the target object's position. While that operation is cheap, even
     /// just the cost of an additional Update() is best avoided for stationary objects.
+    /// 
     /// If the object moves very infrequently under script control, consider using an <see cref="AdjusterFixed"/>,
     /// and notifying it after moves with <see cref="AdjusterFixed.UpdatePosition"/>.
     /// </remarks>

--- a/DocGen/Documentation/Concepts/Advanced/AttachmentPoints.md
+++ b/DocGen/Documentation/Concepts/Advanced/AttachmentPoints.md
@@ -12,7 +12,11 @@ Using Unity's WorldAnchor system, the two anchors would just silently move into 
 
 But World Locking Tools guarantees that in world locked space, non-moving objects will "mostly" never move. And in fact, any motion is up to the owning application.
 
-Attachment points are the codification of that contract between World Locking Tools and the application. An application creates and positions attachment points using World Locking Tools APIs. When a correction in the position of an attachment point is determined by a refit operation, the application is notified via callback of the new position in world locked space that will keep the attachment point at its old position in physical space.
+Another common "abnormal" condition is **loss of tracking**. When tracking is lost in one environment (e.g. room) and regained in another environment, then at first there is no information linking the two spaces. The coordinates in one space are meaningless relative to coordinates in the other space. The attachment point paradigm allows the application to gracefully handle the initial phase when spatial information about the old space is unknown (e.g. by hiding the objects in that old space), as well as recovering when the spatial relationship between the two spaces does become known.
+
+More discussion can be found of these special conditions and the [refit operations](RefitOperations.md) which WLT performs to handle them. The discussion here is focused on the contract between WLT and the application on smoothly resolving such conditions.
+
+Attachment points are the codification of that contract between World Locking Tools and the application. An application creates and positions attachment points using World Locking Tools APIs. When a correction in the position of an attachment point is determined by a [refit operation](RefitOperations.md), the application is notified via callback of the new position in world locked space that will keep the attachment point at its old position in physical space.
 
 Some scenarios in which World Locking Tools attachment points might be the solution:
 
@@ -44,9 +48,13 @@ These notifications are broadcast through delegates which the application hands 
 
 How to best handle these notifications is left to the application, as each will have its own considerations. Sample handlers, which are used internally and may be either used as is or used as a starting point for custom implementations, are provided.
 
+## Sample implementations
+
 For an attachment point that is to remain fixed in the physical world, and which should hide its contents when its tracking is not valid, [AdjusterFixed](xref:Microsoft.MixedReality.WorldLocking.Tools.AdjusterFixed) implements the [AdjustStateDelegate](xref:Microsoft.MixedReality.WorldLocking.Core.AdjustStateDelegate) with its HandleAdjustState member,and the [AdjustLocationDelegate](xref:Microsoft.MixedReality.WorldLocking.Core.AdjustLocationDelegate) with its HandleAdjustLocation member. A similar component for moving objects is in [AdjusterMoving](xref:Microsoft.MixedReality.WorldLocking.Tools.AdjusterMoving).
 
 It is worth noting that supplying either or both these delegates is optional, and in fact reactions to state and location changes may be implemented based on polling rather than events. But unless their use is impossible due to specifics of the application, the event based system using delegates forms a much more efficient implementation.
+
+The recommendation is that you start with the AdjusterFixed component (or very similar AdjusterMoving), and modify the handlers [HandleAdjustLocation](xref:Microsoft.MixedReality.WorldLocking.Tools.AdjusterFixed.HandleAdjustLocation*) and [HandleAdjustState](xref:Microsoft.MixedReality.WorldLocking.Tools.AdjusterFixed.HandleAdjustState*) to suit your applications needs.
 
 ## See also
 

--- a/DocGen/Documentation/Concepts/Advanced/RefitOperations.md
+++ b/DocGen/Documentation/Concepts/Advanced/RefitOperations.md
@@ -47,6 +47,8 @@ In either merge or refreeze, the reaction to refit events is up to the applicati
 
 The point is that World Locking Tools has no dependence on how or whether the application reacts to refit operations. It is entirely up to the application developer's needs.
 
+The preferred mechanism for notification and reaction to refit operations is the [Attachment point](AttachmentPoints.md). More details and options are discussed there.
+
 ## See also
 
 * [Attachment points](AttachmentPoints.md)


### PR DESCRIPTION
The transform remains the preferred interface for retrieving the model position for a SpacePin, but there are situations when the transform is inappropriate.

Specifically, when a model's transforms have been "baked" into the geometry during export from a modeling package or import into Unity, then while the position information for a marker object is still available in the vertex data, the position in the transform is now meaningless.

In those cases, a position might still be extracted from the world bounds of either the object's renderer, or the object's collider.

This change allows the application to specify the source of the SpacePin's model position, as one of:

1. Transform's world-space position - transform.position
2. Renderer's world-space bounds - renderer.bounds.center
3. Collider's world-space bounds - collider.bounds.center