### PR TITLE
Fixup the space pin visualizer.

### DIFF
--- a/Assets/WorldLocking.Core/Scripts/AlignSubtree.cs
+++ b/Assets/WorldLocking.Core/Scripts/AlignSubtree.cs
@@ -204,7 +204,7 @@ namespace Microsoft.MixedReality.WorldLocking.Core
         /// <summary>
         /// Fired when a new AlignmentManager has been created throughout CheckInternalWiring
         /// </summary>
-        public event EventHandler<AlignmentManager> OnAlignManagerCreated;
+        public event EventHandler<IAlignmentManager> OnAlignManagerCreated;
 
         #endregion Public APIs
 

--- a/Assets/WorldLocking.Core/Scripts/AlignmentManager.cs
+++ b/Assets/WorldLocking.Core/Scripts/AlignmentManager.cs
@@ -100,9 +100,7 @@ namespace Microsoft.MixedReality.WorldLocking.Core
 
         #region Public events
 
-        /// <summary>
-        /// New triangulation was built based upon recent poses.
-        /// </summary>
+        /// <inheritdocs />
         public event EventHandler<Triangulator.ITriangulator> OnTriangulationBuilt;
 
         #endregion

--- a/Assets/WorldLocking.Core/Scripts/IAlignmentManager.cs
+++ b/Assets/WorldLocking.Core/Scripts/IAlignmentManager.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.WorldLocking.Core
@@ -38,6 +39,11 @@ namespace Microsoft.MixedReality.WorldLocking.Core
         /// </summary>
         /// <param name="del">Delegate to remove from notifications.</param>
         void UnregisterForLoad(PostAlignmentLoadedDelegate del);
+
+        /// <summary>
+        /// New triangulation was built based upon recent poses.
+        /// </summary>
+        event EventHandler<Triangulator.ITriangulator> OnTriangulationBuilt;
 
         /// <summary>
         /// Add an anchor for aligning a virtual pose to a pose in real space. 

--- a/Assets/WorldLocking.Core/Scripts/WorldLockingManager.cs
+++ b/Assets/WorldLocking.Core/Scripts/WorldLockingManager.cs
@@ -29,7 +29,7 @@ namespace Microsoft.MixedReality.WorldLocking.Core
         /// allowing quick visual verification of the version of World Locking Tools for Unity currently installed.
         /// It has no effect in code, but serves only as a label.
         /// </summary>
-        public static string Version => "1.2.0";
+        public static string Version => "1.2.1";
 
         /// <summary>
         /// The configuration settings may only be set as a block.

--- a/Assets/WorldLocking.Tools/Scripts/SpacePinMeshVisualizer.cs
+++ b/Assets/WorldLocking.Tools/Scripts/SpacePinMeshVisualizer.cs
@@ -32,8 +32,19 @@ namespace Microsoft.MixedReality.WorldLocking.Tools
         /// <summary>
         /// Subtree whose SpacePins should be visualized. Null for global AlignmentManager.
         /// </summary>
+        [SerializeField]
         [Tooltip("Subtree whose SpacePins should be visualized. Null for global AlignmentManager.")]
-        public AlignSubtree targetSubtree = null;
+        private AlignSubtree targetSubtree = null;
+
+        public AlignSubtree TargetSubtree
+        {
+            get { return targetSubtree; }
+            set
+            {
+                targetSubtree = value;
+                FindAlignmentManager();
+            }
+        }
 
         private IAlignmentManager alignmentManager = null;
         private SimpleTriangulator triangulator = null;
@@ -480,11 +491,6 @@ namespace Microsoft.MixedReality.WorldLocking.Tools
             return wltMgr.FrozenFromSpongy.Multiply(wltMgr.SpongyFromCamera).position;
         }
 
-        private void Awake()
-        {
-            FindAlignmentManager();
-        }
-
         private void FindAlignmentManager()
         {
             AlignSubtree subTree = targetSubtree;
@@ -500,19 +506,17 @@ namespace Microsoft.MixedReality.WorldLocking.Tools
 
         private void FindAlignmentManagerFromSubtree(AlignSubtree subTree)
         {
-            if (subTree != null)
+            Debug.Assert(subTree != null, "Trying to find alignment manager from null subTree.");
+            if (subTree.AlignmentManager == null)
             {
-                if (subTree.AlignmentManager == null)
+                subTree.OnAlignManagerCreated += (sender, manager) =>
                 {
-                    subTree.OnAlignManagerCreated += (sender, manager) =>
-                    {
-                        SetAlignmentManager(manager);
-                    };
-                }
-                else
-                {
-                    SetAlignmentManager(subTree.AlignmentManager);
-                }
+                    SetAlignmentManager(manager);
+                };
+            }
+            else
+            {
+                SetAlignmentManager(subTree.AlignmentManager);
             }
         }
 
@@ -550,6 +554,10 @@ namespace Microsoft.MixedReality.WorldLocking.Tools
 
         private void Update()
         {
+            if (alignmentManager == null)
+            {
+                FindAlignmentManager();
+            }
             if (triangulator != null && isVisible)
             {
                 // Find the three closest SpacePins this frame

--- a/Assets/WorldLocking.Tools/Scripts/SpacePinMeshVisualizer.cs
+++ b/Assets/WorldLocking.Tools/Scripts/SpacePinMeshVisualizer.cs
@@ -29,13 +29,13 @@ namespace Microsoft.MixedReality.WorldLocking.Tools
 
         public GameObject percentageWorldSpaceCanvasPrefab;
 
-        /// <summary>
-        /// Subtree whose SpacePins should be visualized. Null for global AlignmentManager.
-        /// </summary>
         [SerializeField]
         [Tooltip("Subtree whose SpacePins should be visualized. Null for global AlignmentManager.")]
         private AlignSubtree targetSubtree = null;
 
+        /// <summary>
+        /// Subtree whose SpacePins should be visualized. Null for global AlignmentManager.
+        /// </summary>
         public AlignSubtree TargetSubtree
         {
             get { return targetSubtree; }

--- a/Assets/WorldLocking.Tools/Scripts/SpacePinMeshVisualizer.cs
+++ b/Assets/WorldLocking.Tools/Scripts/SpacePinMeshVisualizer.cs
@@ -29,6 +29,10 @@ namespace Microsoft.MixedReality.WorldLocking.Tools
 
         public GameObject percentageWorldSpaceCanvasPrefab;
 
+        /// <summary>
+        /// Subtree whose SpacePins should be visualized. Null for global AlignmentManager.
+        /// </summary>
+        [Tooltip("Subtree whose SpacePins should be visualized. Null for global AlignmentManager.")]
         public AlignSubtree targetSubtree = null;
 
         private IAlignmentManager alignmentManager = null;
@@ -484,10 +488,6 @@ namespace Microsoft.MixedReality.WorldLocking.Tools
         private void FindAlignmentManager()
         {
             AlignSubtree subTree = targetSubtree;
-            if (subTree == null)
-            {
-                subTree = GetComponent<AlignSubtree>();
-            }
             if (subTree != null)
             {
                 FindAlignmentManagerFromSubtree(subTree);

--- a/Assets/WorldLocking.Tools/Scripts/SpacePinMeshVisualizer.cs
+++ b/Assets/WorldLocking.Tools/Scripts/SpacePinMeshVisualizer.cs
@@ -16,17 +16,6 @@ namespace Microsoft.MixedReality.WorldLocking.Tools
     public class SpacePinMeshVisualizer : MonoBehaviour
     {
 
-        private static SpacePinMeshVisualizer instance = null;
-        public static SpacePinMeshVisualizer Instance
-        {
-            get
-            {
-                if (instance == null)
-                    instance = FindObjectOfType<SpacePinMeshVisualizer>();
-                return instance;
-            }
-        }
-
         [Range(0.1f, 2.0f)]
         public float weightCubeMaxSize = 1.0f;
 
@@ -40,7 +29,9 @@ namespace Microsoft.MixedReality.WorldLocking.Tools
 
         public GameObject percentageWorldSpaceCanvasPrefab;
 
-        private AlignmentManager alignmentManager = null;
+        public AlignSubtree targetSubtree = null;
+
+        private IAlignmentManager alignmentManager = null;
         private SimpleTriangulator triangulator = null;
         private Interpolant currentInterpolant = null;
 
@@ -102,7 +93,7 @@ namespace Microsoft.MixedReality.WorldLocking.Tools
         /// Injecting the reference to the triangulation that was newly built.
         /// </summary>
         /// <param name="triangulator">Reference to the data on the triangle that was built.</param>
-        public void Initialize(ITriangulator triangulator)
+        private void Initialize(ITriangulator triangulator)
         {
             this.triangulator = (SimpleTriangulator)triangulator;
 
@@ -129,7 +120,7 @@ namespace Microsoft.MixedReality.WorldLocking.Tools
                 }
             }
 
-            transform.position = new Vector3(transform.position.x, GetLockedHeadPosition().y + verticalOffset, transform.position.z);
+            transform.position = new Vector3(transform.position.x, GetFrozenHeadPosition().y + verticalOffset, transform.position.z);
             triangleIsDirty = true;
         }
 
@@ -137,7 +128,7 @@ namespace Microsoft.MixedReality.WorldLocking.Tools
         /// Generates the whole mesh inside the triangulation data, except for the boundry triangles/vertices.
         /// </summary>
         /// <returns></returns>
-        Mesh GenerateTriangulationWireFrameMesh()
+        private Mesh GenerateTriangulationWireFrameMesh()
         {
             Mesh wholeMesh = new Mesh();
 
@@ -146,8 +137,10 @@ namespace Microsoft.MixedReality.WorldLocking.Tools
 
             Array.Copy(originalVertices, 4, vertices, 0, originalVertices.Length - 4);
 
+            Pose frozenFromLocked = WorldLockingManager.GetInstance().FrozenFromLocked;
             for (int i = 0; i < vertices.Length; i++)
             {
+                vertices[i] = frozenFromLocked.Multiply(vertices[i]);
                 vertices[i].y = 0.0f;
             }
 
@@ -380,6 +373,11 @@ namespace Microsoft.MixedReality.WorldLocking.Tools
             secondPinPosition = currentBoundaryVertexIDx == 1 ? lockedHeadPosition : triangulator.Vertices[currentInterpolant.idx[1] + 4];
             thirdPinPosition = currentBoundaryVertexIDx == 2 ? lockedHeadPosition : triangulator.Vertices[currentInterpolant.idx[2] + 4];
 
+            Pose frozenFromLocked = WorldLockingManager.GetInstance().FrozenFromLocked;
+            firstPinPosition = frozenFromLocked.Multiply(firstPinPosition);
+            secondPinPosition = frozenFromLocked.Multiply(secondPinPosition);
+            thirdPinPosition = frozenFromLocked.Multiply(thirdPinPosition);
+
             //    DEBUG TRIANGLE    //
             //firstPinPosition = new Vector3(5.0f, 0.0f, 0.0f);
             //secondPinPosition = new Vector3(1.0f, 0.0f, 1.0f);
@@ -472,25 +470,62 @@ namespace Microsoft.MixedReality.WorldLocking.Tools
             return lockedHeadPose.position;
         }
 
+        private Vector3 GetFrozenHeadPosition()
+        {
+            WorldLockingManager wltMgr = WorldLockingManager.GetInstance();
+            return wltMgr.FrozenFromSpongy.Multiply(wltMgr.SpongyFromCamera).position;
+        }
+
         private void Awake()
         {
-            AlignSubtree subTree = FindObjectOfType<AlignSubtree>();
+            FindAlignmentManager();
+        }
 
+        private void FindAlignmentManager()
+        {
+            AlignSubtree subTree = targetSubtree;
+            if (subTree == null)
+            {
+                subTree = GetComponent<AlignSubtree>();
+            }
+            if (subTree != null)
+            {
+                FindAlignmentManagerFromSubtree(subTree);
+            }
+            else
+            {
+                SetAlignmentManager(WorldLockingManager.GetInstance().AlignmentManager);
+            }
+        }
+
+        private void FindAlignmentManagerFromSubtree(AlignSubtree subTree)
+        {
             if (subTree != null)
             {
                 if (subTree.AlignmentManager == null)
                 {
                     subTree.OnAlignManagerCreated += (sender, manager) =>
                     {
-                        this.alignmentManager = manager;
-                        alignmentManager.OnTriangulationBuilt += OnNewTriangulationWasBuilt;
+                        SetAlignmentManager(manager);
                     };
                 }
                 else
                 {
-                    this.alignmentManager = subTree.AlignmentManager;
-                    alignmentManager.OnTriangulationBuilt += OnNewTriangulationWasBuilt;
+                    SetAlignmentManager(subTree.AlignmentManager);
                 }
+            }
+        }
+
+        private void SetAlignmentManager(IAlignmentManager manager)
+        {
+            if (alignmentManager != null)
+            {
+                alignmentManager.OnTriangulationBuilt -= OnNewTriangulationWasBuilt;
+            }
+            alignmentManager = manager;
+            if (alignmentManager != null)
+            {
+                alignmentManager.OnTriangulationBuilt += OnNewTriangulationWasBuilt;
             }
         }
 
@@ -508,7 +543,9 @@ namespace Microsoft.MixedReality.WorldLocking.Tools
         private void OnDestroy()
         {
             if (alignmentManager != null)
+            {
                 alignmentManager.OnTriangulationBuilt -= OnNewTriangulationWasBuilt;
+            }
         }
 
         private void Update()


### PR DESCRIPTION
Allow visualization of multiple Space Pin groups (AlignSubtrees). Fixes #90 

Allow visualization of global Space Pin (WorldLockingManager's AlignmentManager).

> NOTE: This is a breaking change. The previous behavior found the first AlignSubtree in the scene (indeterminate), and visualized that with a global visualizer instance. A SpacePinVisualizer without its Target Subtree field set will now visualize the global AlignmentManager's SpacePins, rather than picking an AlignSubtree from the scene.