### PR TITLE
Use defines to proof against lack of Legacy WSA in Unity 2020.

### DIFF
--- a/Assets/WorldLocking.Core/Scripts/AnchorManager.cs
+++ b/Assets/WorldLocking.Core/Scripts/AnchorManager.cs
@@ -65,7 +65,6 @@ namespace Microsoft.MixedReality.WorldLocking.Core
 
         protected abstract float TrackingStartDelayTime { get; }
 
-        // UNITY_WSA - abstract?
         protected abstract bool IsTracking();
 
         // mafinc - this ErrorStatus would be well refactored.
@@ -469,7 +468,6 @@ namespace Microsoft.MixedReality.WorldLocking.Core
             await SaveAnchors(spongyAnchors);
         }
 
-        // UNITY_WSA - abstract?
         protected virtual async Task SaveAnchors(List<SpongyAnchorWithId> spongyAnchors)
         {
             await Task.CompletedTask;
@@ -485,7 +483,6 @@ namespace Microsoft.MixedReality.WorldLocking.Core
         /// Likewise, when a spongy anchor fails to load, this routine will delete its frozen
         /// counterpart from the plugin.
         /// </remarks>
-        /// UNITY_WSA
         public async Task LoadAnchors()
         {
             await LoadAnchors(plugin, newAnchorId, worldAnchorParent, spongyAnchors);
@@ -499,7 +496,6 @@ namespace Microsoft.MixedReality.WorldLocking.Core
             }
         }
 
-        // UNITY_WSA - abstract?
         protected virtual async Task LoadAnchors(IPlugin plugin, AnchorId firstId, Transform parent, List<SpongyAnchorWithId> spongyAnchors)
         {
             await Task.CompletedTask;

--- a/Assets/WorldLocking.Core/Scripts/SpongyAnchor.cs
+++ b/Assets/WorldLocking.Core/Scripts/SpongyAnchor.cs
@@ -2,10 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using UnityEngine;
-#if UNITY_WSA
-using UnityEngine.XR.WSA;
-using UnityEngine.XR.WSA.Persistence;
-#endif // UNITY_WSA
 
 namespace Microsoft.MixedReality.WorldLocking.Core
 {

--- a/Assets/WorldLocking.Core/Scripts/WSA/AnchorManagerWSA.cs
+++ b/Assets/WorldLocking.Core/Scripts/WSA/AnchorManagerWSA.cs
@@ -3,16 +3,20 @@
 
 #pragma warning disable CS0618
 
+#if UNITY_WSA && !UNITY_2020_1_OR_NEWER
+#define WLT_ENABLE_LEGACY_WSA
+#endif
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.XR;
-#if UNITY_WSA
+#if WLT_ENABLE_LEGACY_WSA
 using UnityEngine.XR.WSA;
 using UnityEngine.XR.WSA.Persistence;
-#endif // UNITY_WSA
+#endif // WLT_ENABLE_LEGACY_WSA
 
 namespace Microsoft.MixedReality.WorldLocking.Core
 {
@@ -61,11 +65,11 @@ namespace Microsoft.MixedReality.WorldLocking.Core
 
         protected override bool IsTracking()
         {
-#if UNITY_WSA
+#if WLT_ENABLE_LEGACY_WSA
             return UnityEngine.XR.WSA.WorldManager.state == UnityEngine.XR.WSA.PositionalLocatorState.Active;
-#else // UNITY_WSA
+#else // WLT_ENABLE_LEGACY_WSA
             return true;
-#endif // UNITY_WSA
+#endif // WLT_ENABLE_LEGACY_WSA
         }
 
         protected override SpongyAnchor CreateAnchor(AnchorId id, Transform parent, Pose initialPose)
@@ -87,7 +91,7 @@ namespace Microsoft.MixedReality.WorldLocking.Core
             return null;
         }
 
-#if UNITY_WSA
+#if WLT_ENABLE_LEGACY_WSA
         /// <summary>
         /// Convert WorldAnchorStore.GetAsync call into a modern C# async call
         /// </summary>
@@ -101,11 +105,11 @@ namespace Microsoft.MixedReality.WorldLocking.Core
             });
             return await tcs.Task;
         }
-#endif // UNITY_WSA
+#endif // WLT_ENABLE_LEGACY_WSA
 
         protected override async Task SaveAnchors(List<SpongyAnchorWithId> spongyAnchors)
         {
-#if UNITY_WSA
+#if WLT_ENABLE_LEGACY_WSA
 
             var worldAnchorStore = await getWorldAnchorStoreAsync();
             foreach (var keyval in spongyAnchors)
@@ -119,9 +123,9 @@ namespace Microsoft.MixedReality.WorldLocking.Core
                     wsaAnchor.Save(worldAnchorStore);
                 }
             }
-#else // UNITY_WSA
+#else // WLT_ENABLE_LEGACY_WSA
             await Task.CompletedTask;
-#endif // UNITY_WSA
+#endif // WLT_ENABLE_LEGACY_WSA
         }
 
 
@@ -137,7 +141,7 @@ namespace Microsoft.MixedReality.WorldLocking.Core
         /// </remarks>
         protected override async Task LoadAnchors(IPlugin plugin, AnchorId firstId, Transform parent, List<SpongyAnchorWithId> spongyAnchors)
         {
-#if UNITY_WSA
+#if WLT_ENABLE_LEGACY_WSA
             var worldAnchorStore = await getWorldAnchorStoreAsync();
 
             var anchorIds = plugin.GetFrozenAnchorIds();
@@ -172,9 +176,9 @@ namespace Microsoft.MixedReality.WorldLocking.Core
                 }
             }
 
-#else // UNITY_WSA
+#else // WLT_ENABLE_LEGACY_WSA
             await Task.CompletedTask;
-#endif // UNITY_WSA
+#endif // WLT_ENABLE_LEGACY_WSA
         }
     }
 }

--- a/Assets/WorldLocking.Core/Scripts/WSA/SpongyAnchorWSA.cs
+++ b/Assets/WorldLocking.Core/Scripts/WSA/SpongyAnchorWSA.cs
@@ -1,11 +1,15 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+#if UNITY_WSA && !UNITY_2020_1_OR_NEWER
+#define WLT_ENABLE_LEGACY_WSA
+#endif
+
 using UnityEngine;
-#if UNITY_WSA
+#if WLT_ENABLE_LEGACY_WSA
 using UnityEngine.XR.WSA;
 using UnityEngine.XR.WSA.Persistence;
-#endif // UNITY_WSA
+#endif // WLT_ENABLE_LEGACY_WSA
 
 #pragma warning disable CS0618
 
@@ -36,11 +40,11 @@ namespace Microsoft.MixedReality.WorldLocking.Core
 
         private float lastNotLocatedTime = float.NegativeInfinity;
         private bool isSaved = false;
-#if UNITY_WSA
+#if WLT_ENABLE_LEGACY_WSA
         private WorldAnchor worldAnchor = null;
 #else
         private SpongyAnchor dummy = null;
-#endif // UNITY_WSA
+#endif // WLT_ENABLE_LEGACY_WSA
 
         /// <summary>
         /// Returns true if the anchor is reliably located. False might mean loss of tracking or not fully initialized.
@@ -52,11 +56,11 @@ namespace Microsoft.MixedReality.WorldLocking.Core
         {
             get
             {
-#if UNITY_WSA
+#if WLT_ENABLE_LEGACY_WSA
                 return worldAnchor != null && worldAnchor.isLocated;
-#else // UNITY_WSA
+#else // WLT_ENABLE_LEGACY_WSA
                 return false;
-#endif // UNITY_WSA
+#endif // WLT_ENABLE_LEGACY_WSA
             }
         }
 
@@ -71,7 +75,7 @@ namespace Microsoft.MixedReality.WorldLocking.Core
         // Start is called before the first frame update
         private void Start ()
         {
-#if UNITY_WSA
+#if WLT_ENABLE_LEGACY_WSA
             if (worldAnchor == null)
             {
                 worldAnchor = gameObject.AddComponent<UnityEngine.XR.WSA.WorldAnchor>();
@@ -83,10 +87,10 @@ namespace Microsoft.MixedReality.WorldLocking.Core
                 isSaved = false;
                 lastNotLocatedTime = float.NegativeInfinity;
             }
-#endif // UNITY_WSA
+#endif // WLT_ENABLE_LEGACY_WSA
         }
 
-#if UNITY_WSA
+#if WLT_ENABLE_LEGACY_WSA
         // Update is called once per frame
         private void Update ()
         {
@@ -95,9 +99,9 @@ namespace Microsoft.MixedReality.WorldLocking.Core
                 lastNotLocatedTime = Time.unscaledTime;
             }
         }
-#endif // UNITY_WSA
+#endif // WLT_ENABLE_LEGACY_WSA
 
-#if UNITY_WSA
+#if WLT_ENABLE_LEGACY_WSA
 
         /// <summary>
         /// Save to the anchor store, replacing any existing anchor (by name).
@@ -135,6 +139,6 @@ namespace Microsoft.MixedReality.WorldLocking.Core
             isSaved = true;
             return worldAnchor != null;
         }
-#endif // UNITY_WSA
+#endif // WLT_ENABLE_LEGACY_WSA
     }
 }

--- a/Assets/WorldLocking.Core/Scripts/WorldLockingManager.cs
+++ b/Assets/WorldLocking.Core/Scripts/WorldLockingManager.cs
@@ -430,7 +430,7 @@ namespace Microsoft.MixedReality.WorldLocking.Core
                 Debug.Log("Failed to create requested XR SDK anchor manager!");
             }
 #endif // WLT_ARSUBSYSTEMS_PRESENT
-#if UNITY_WSA
+#if UNITY_WSA && !UNITY_2020_1_OR_NEWER
             if (anchorSettings.anchorSubsystem == AnchorSettings.AnchorSubsystem.WSA)
             {
                 AnchorManagerWSA wsaAnchorManager = AnchorManagerWSA.TryCreate(plugin, headTracker);
@@ -558,7 +558,6 @@ namespace Microsoft.MixedReality.WorldLocking.Core
             // into the FrozenWorld engine
             bool hasSpongyAnchors = AnchorManager.Update();
 
-//#if UNITY_WSA
             if (!hasSpongyAnchors)
             {
                 // IFragmentManager.Pause() will set all fragments to disconnected.
@@ -566,7 +565,6 @@ namespace Microsoft.MixedReality.WorldLocking.Core
                 FragmentManager.Pause();
                 return;
             }
-//#endif // UNITY_WSA
 
             try
             {
@@ -736,11 +734,12 @@ namespace Microsoft.MixedReality.WorldLocking.Core
         /// </summary>
         public void Save()
         {
-#if UNITY_WSA
-            /// Persistence currently only supported on HoloLens
-            WrapErrors(saveAsync());
-            alignmentManager.Save();
-#endif // UNITY_WSA
+            if (shared.anchorSettings.anchorSubsystem == AnchorSettings.AnchorSubsystem.WSA)
+            {
+                /// Persistence currently only supported on HoloLens Legacy
+                WrapErrors(saveAsync());
+                alignmentManager.Save();
+            }
         }
 
         /// <summary>
@@ -748,11 +747,12 @@ namespace Microsoft.MixedReality.WorldLocking.Core
         /// </summary>
         public void Load()
         {
-#if UNITY_WSA
-            /// Persistence currently only supported on HoloLens
-            WrapErrors(loadAsync());
-            alignmentManager.Load();
-#endif // UNITY_WSA
+            if (shared.anchorSettings.anchorSubsystem == AnchorSettings.AnchorSubsystem.WSA)
+            {
+                /// Persistence currently only supported on HoloLens Legacy
+                WrapErrors(loadAsync());
+                alignmentManager.Load();
+            }
         }
 
         #endregion
@@ -864,13 +864,14 @@ namespace Microsoft.MixedReality.WorldLocking.Core
         /// </summary>
         private void AutoSaveTriggerHook()
         {
-#if UNITY_WSA
-            /// Persistence currently only supported on HoloLens
-            if (AutoSave && Time.unscaledTime >= lastSavingTime + AutoSaveInterval)
+            if (shared.anchorSettings.anchorSubsystem == AnchorSettings.AnchorSubsystem.WSA)
             {
-                WrapErrors(saveAsync());
+                /// Persistence currently only supported on HoloLens
+                if (AutoSave && Time.unscaledTime >= lastSavingTime + AutoSaveInterval)
+                {
+                    WrapErrors(saveAsync());
+                }
             }
-#endif // UNITY_WSA
         }
 
         /// <summary>

--- a/Assets/WorldLocking.Tests/Core/Scripts/SaveLoadTest.cs
+++ b/Assets/WorldLocking.Tests/Core/Scripts/SaveLoadTest.cs
@@ -1,6 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+#if UNITY_WSA && !UNITY_2020_1_OR_NEWER
+#define WLT_ENABLE_SAVE_LOAD_TESTS
+#endif
+
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -67,7 +71,7 @@ namespace Microsoft.MixedReality.WorldLocking.Tests.Core
                 }
             };
 
-#if UNITY_WSA
+#if WLT_ENABLE_SAVE_LOAD_TESTS
         [UnityTest]
         public IEnumerator SaveLoadIndieAlign()
         {
@@ -145,7 +149,7 @@ namespace Microsoft.MixedReality.WorldLocking.Tests.Core
             yield return null;
 
         }
-#endif // UNITY_WSA
+#endif // WLT_ENABLE_SAVE_LOAD_TESTS
 
         private SpacePin FindPinByName(GameObject rig, string pinName)
         {
@@ -182,7 +186,7 @@ namespace Microsoft.MixedReality.WorldLocking.Tests.Core
             spacePin.SetFrozenPose(frozenPose);
         }
 
-#if UNITY_WSA
+#if WLT_ENABLE_SAVE_LOAD_TESTS
         [UnityTest]
         public IEnumerator SaveLoadTestSaveThenLoad()
         {
@@ -251,7 +255,7 @@ namespace Microsoft.MixedReality.WorldLocking.Tests.Core
 
             yield return null;
         }
-#endif // UNITY_WSA
+#endif // WLT_ENABLE_SAVE_LOAD_TESTS
 
         private void VerifyAlignmentIdentity(IAlignmentManager alignMgr, PinData[] pinData)
         {

--- a/Assets/WorldLocking.Tools/Scripts/FrozenSpatialMapping.cs
+++ b/Assets/WorldLocking.Tools/Scripts/FrozenSpatialMapping.cs
@@ -3,11 +3,15 @@
 
 #pragma warning disable CS0618
 
+#if UNITY_WSA && !UNITY_2020_1_OR_NEWER
+#define WLT_ENABLE_LEGACY_WSA
+#endif
+
 using UnityEngine;
-#if UNITY_WSA
+#if WLT_ENABLE_LEGACY_WSA
 using UnityEngine.XR;
 using UnityEngine.XR.WSA;
-#endif // UNITY_WSA
+#endif // WLT_ENABLE_LEGACY_WSA
 using UnityEngine.Rendering;
 using UnityEngine.Assertions;
 using System;
@@ -46,12 +50,12 @@ namespace Microsoft.MixedReality.WorldLocking.Tools
             public BakedState currentState = BakedState.NeverBaked;
         }
 
-#if UNITY_WSA
+#if WLT_ENABLE_LEGACY_WSA
         /// <summary>
         /// Interface to spatial mapping
         /// </summary>
         private SurfaceObserver observer;
-#endif // UNITY_WSA
+#endif // WLT_ENABLE_LEGACY_WSA
 
         /// <summary>
         /// Store known surfaces by handle.
@@ -94,9 +98,9 @@ namespace Microsoft.MixedReality.WorldLocking.Tools
                 display = value;
                 if (Display != oldDisplay)
                 {
-#if UNITY_WSA
+#if WLT_ENABLE_LEGACY_WSA
                     ChangeDisplayState();
-#endif // UNITY_WSA 
+#endif // WLT_ENABLE_LEGACY_WSA 
                 }
             }
         }
@@ -209,16 +213,16 @@ namespace Microsoft.MixedReality.WorldLocking.Tools
 
         private void Setup()
         {
-#if UNITY_WSA
+#if WLT_ENABLE_LEGACY_WSA
             Debug.Assert(observer == null, "Setting up an already setup FrozenSpatialMapping");
             observer = new SurfaceObserver();
             observer.SetVolumeAsSphere(Vector3.zero, Radius);
-#endif // UNITY_WSA
+#endif // WLT_ENABLE_LEGACY_WSA
         }
 
         private void Teardown()
         {
-#if UNITY_WSA
+#if WLT_ENABLE_LEGACY_WSA
             Debug.Assert(observer != null, "Tearing down FrozenSpatialMapping that isn't set up.");
             foreach (var surface in surfaces.Values)
             {
@@ -227,21 +231,21 @@ namespace Microsoft.MixedReality.WorldLocking.Tools
             surfaces.Clear();
             observer.Dispose();
             observer = null;
-#endif // UNITY_WSA
+#endif // WLT_ENABLE_LEGACY_WSA
         }
 
         private void Update()
         {
-#if UNITY_WSA
+#if WLT_ENABLE_LEGACY_WSA
             if (CheckState())
             {
                 UpdateObserver();
                 UpdateSurfaces();
             }
-#endif // UNITY_WSA
+#endif // WLT_ENABLE_LEGACY_WSA
         }
 
-#if UNITY_WSA
+#if WLT_ENABLE_LEGACY_WSA
         private bool CheckState()
         {
             if (Active)
@@ -463,6 +467,6 @@ namespace Microsoft.MixedReality.WorldLocking.Tools
                 Assert.IsTrue(false);
             }
         }
-#endif // UNITY_WSA
+#endif // WLT_ENABLE_LEGACY_WSA
     }
 }

--- a/Assets/WorldLocking.Tools/Scripts/FrozenTapToAdd.cs
+++ b/Assets/WorldLocking.Tools/Scripts/FrozenTapToAdd.cs
@@ -3,10 +3,14 @@
 
 #pragma warning disable CS0618
 
+#if UNITY_WSA && !UNITY_2020_1_OR_NEWER
+#define WLT_ENABLE_LEGACY_WSA
+#endif
+
 using UnityEngine;
-#if UNITY_WSA
+#if WLT_ENABLE_LEGACY_WSA
 using UnityEngine.XR.WSA.Input;
-#endif // UNITY_WSA
+#endif // WLT_ENABLE_LEGACY_WSA
 
 using Microsoft.MixedReality.WorldLocking.Core;
 
@@ -32,26 +36,26 @@ namespace Microsoft.MixedReality.WorldLocking.Tools
         /// </summary>
         public bool Active { get; set; }
 
-#if UNITY_WSA
+#if WLT_ENABLE_LEGACY_WSA
         private GestureRecognizer gestureRecognizer;
-#endif // UNITY_WSA
+#endif // WLT_ENABLE_LEGACY_WSA
 
         private WorldLockingManager manager {  get { return WorldLockingManager.GetInstance(); } }
 
         // Start is called before the first frame update
         private void Start()
         {
-#if UNITY_WSA
+#if WLT_ENABLE_LEGACY_WSA
             gestureRecognizer = new GestureRecognizer();
             gestureRecognizer.SetRecognizableGestures(GestureSettings.Tap);
 
             gestureRecognizer.Tapped += HandleTapped;
 
             gestureRecognizer.StartCapturingGestures();
-#endif // UNITY_WSA
+#endif // WLT_ENABLE_LEGACY_WSA
         }
 
-#if UNITY_WSA
+#if WLT_ENABLE_LEGACY_WSA
         private void HandleTapped(TappedEventArgs eventArgs)
         {
             
@@ -87,6 +91,6 @@ namespace Microsoft.MixedReality.WorldLocking.Tools
                 }
             }
         }
-#endif // UNITY_WSA
+#endif // WLT_ENABLE_LEGACY_WSA
     }
 }

--- a/Assets/WorldLocking.Tools/Scripts/ToggleWorldAnchor.cs
+++ b/Assets/WorldLocking.Tools/Scripts/ToggleWorldAnchor.cs
@@ -1,13 +1,17 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+#if UNITY_WSA && !UNITY_2020_1_OR_NEWER
+#define WLT_ENABLE_LEGACY_WSA
+#endif
+
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-#if UNITY_WSA
+#if WLT_ENABLE_LEGACY_WSA
 using UnityEngine.XR.WSA;
-#endif // UNITY_WSA
+#endif // WLT_ENABLE_LEGACY_WSA
 
 using Microsoft.MixedReality.WorldLocking.Core;
 
@@ -17,9 +21,9 @@ namespace Microsoft.MixedReality.WorldLocking.Tools
     {
         protected IAttachmentPoint AttachmentPoint { get; private set; }
 
-#if UNITY_WSA
+#if WLT_ENABLE_LEGACY_WSA
         private WorldAnchor worldAnchor = null;
-#endif // UNITY_WSA
+#endif // WLT_ENABLE_LEGACY_WSA
 
         private bool frozenPoseIsSpongy = false;
         private Pose frozenPose = Pose.identity;
@@ -45,21 +49,21 @@ namespace Microsoft.MixedReality.WorldLocking.Tools
 
         private void OnEnable()
         {
-#if UNITY_WSA
+#if WLT_ENABLE_LEGACY_WSA
             /// Setup world anchor helper.
             CreateWorldAnchorHelper();
-#endif // UNITY_WSA
+#endif // WLT_ENABLE_LEGACY_WSA
         }
 
         private void OnDisable()
         {
-#if UNITY_WSA
+#if WLT_ENABLE_LEGACY_WSA
             /// Tear down world anchor helper.
             DestroyWorldAnchorHelper();
-#endif // UNITY_WSA
+#endif // WLT_ENABLE_LEGACY_WSA
         }
 
-#if UNITY_WSA
+#if WLT_ENABLE_LEGACY_WSA
         // Update is called once per frame
         void Update()
         {
@@ -128,7 +132,7 @@ namespace Microsoft.MixedReality.WorldLocking.Tools
                 AttachmentPoint = null;
             }
         }
-#endif // UNITY_WSA
+#endif // WLT_ENABLE_LEGACY_WSA
 
     }
 }


### PR DESCRIPTION
No functional change, but excludes Legacy WSA (removed from Unity 2020) code from compilation.

XRSDK anchor management supported (don't forget to change Anchor Management setting in World Locking Context!).

Fixes #114 