### PR TITLE
Give the samples package its own meta files 

### DIFF
--- a/UPM/samples_files/CHANGELOG.md.meta
+++ b/UPM/samples_files/CHANGELOG.md.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: bc4df37583bc3294b907c496d4f6d6dd
+guid: 8f1540f25350fba4e98054eecdc546a3
 TextScriptImporter:
   externalObjects: {}
   userData: 

--- a/UPM/samples_files/LICENSE.md.meta
+++ b/UPM/samples_files/LICENSE.md.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: df468ad7ab7df1c4eb1d72177a4b5859
+guid: 25382b09ec793b843b0b131f63843f39
 TextScriptImporter:
   externalObjects: {}
   userData: 

--- a/UPM/samples_files/NOTICE.md.meta
+++ b/UPM/samples_files/NOTICE.md.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 616f81a0fe106044cadb125f5a8f1f6f
+guid: e9f3fcf1d88ab3b418216d76ab4ccf6c
 TextScriptImporter:
   externalObjects: {}
   userData: 

--- a/UPM/samples_files/package.json.meta
+++ b/UPM/samples_files/package.json.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: d917713df41b8be44b9f95d535126ff8
+guid: 428ae2935afd61e4cb53fd13541e7c50
 TextScriptImporter:
   externalObjects: {}
   userData: 


### PR DESCRIPTION
This is to to avoid collisions with tools package.

Fixes #125 