### PR TITLE
Add a note about running Unity to generate .meta files before packaging.

### DIFF
--- a/UPM/upm_pack.cmd
+++ b/UPM/upm_pack.cmd
@@ -1,6 +1,8 @@
 @echo off
 rem Simple script to create NPM packages suitable for Unity.
 rem Does NOT publish the packages, they will be left in Assets folder.
+rem NOTE: Unity must be run on the project at least once, to ensure all
+rem necessary .meta files are present.
 rem 
 rem Run this script from project's .\UPM folder (where it exists).
 rem 


### PR DESCRIPTION
If the branch is clean, then `nuget restore` can be used to install the Frozen World Engine DLL, but .meta files for it won't be generated until Unity is run on that project. 