### PR TITLE
Mark context and scene as dirty after modification from editor script.

### DIFF
--- a/Assets/WorldLocking.Tools/Editor/WorldLockingSetup.cs
+++ b/Assets/WorldLocking.Tools/Editor/WorldLockingSetup.cs
@@ -170,6 +170,9 @@ namespace Microsoft.MixedReality.WorldLocking.Tools
             CheckAnchorManagement(worldLockingContext);
 
             Selection.activeObject = worldLockingContext.gameObject;
+
+            EditorUtility.SetDirty(worldLockingContext);
+            EditorSceneManager.MarkAllScenesDirty();
         }
 
         /// <summary>


### PR DESCRIPTION
Otherwise changes will be discarded after unloading scene.