### PR TITLE
Update to Frozen World Engine v1.1.1

### DIFF
--- a/Assets/WorldLocking.Core/Scripts/WorldLockingManager.cs
+++ b/Assets/WorldLocking.Core/Scripts/WorldLockingManager.cs
@@ -29,7 +29,7 @@ namespace Microsoft.MixedReality.WorldLocking.Core
         /// allowing quick visual verification of the version of World Locking Tools for Unity currently installed.
         /// It has no effect in code, but serves only as a label.
         /// </summary>
-        public static string Version => "1.3.6";
+        public static string Version => "1.3.7";
 
         /// <summary>
         /// The configuration settings may only be set as a block.

--- a/Assets/packages.config
+++ b/Assets/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.MixedReality.Unity.FrozenWorld.Engine" version="1.1.0" />
+  <package id="Microsoft.MixedReality.Unity.FrozenWorld.Engine" version="1.1.1" />
 </packages>


### PR DESCRIPTION
Note that when you get this update, if you are NOT using NuGet for Unity, you need to delete everything in your Assets/Packages/Microsoft.MixedReality.Unity.FrozenWorld folder. See instructions for [updating Frozen World Engine DLL here](https://microsoft.github.io/MixedReality-WorldLockingTools-Unity/DocGen/Documentation/HowTos/InitialSetup.html#manual-frozen-world-engine-dll-installation).