### PR TITLE
Add Read list of cloud anchors to IPublisher API

### DIFF
--- a/Assets/WorldLocking.ASA/Scripts/IPublisher.cs
+++ b/Assets/WorldLocking.ASA/Scripts/IPublisher.cs
@@ -131,6 +131,8 @@ namespace Microsoft.MixedReality.WorldLocking.ASA
         /// <returns>Awaitable local peg and its properties that were used to create the cloud anchor are reconstructed and returned.</returns>
         Task<LocalPegAndProperties> Read(CloudAnchorId cloudAnchorId);
 
+        Task<Dictionary<CloudAnchorId, LocalPegAndProperties>> Read(IReadOnlyCollection<CloudAnchorId> cloudAnchorIds);
+
         /// <summary>
         /// Delete a cloud anchor, and create a new one based on input local peg and its properties.
         /// </summary>


### PR DESCRIPTION
Working, tested HL2 & Android. 

Motivation for this is that there is significant time overhead to querying ASA for one or more cloud anchor ids. While the time required querying N ids one by one is on the order of a N minutes (N * ~40seconds), querying for N ids on a single watcher is roughly constant time (~40 seconds).

Making find by list default used by SpacePinBinder.