### PR TITLE
Workaround for new OpenXR issue. 

### DIFF
--- a/Assets/WorldLocking.ASA.Examples/Scenes/PinTestSofa.unity
+++ b/Assets/WorldLocking.ASA.Examples/Scenes/PinTestSofa.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 705507994}
-  m_IndirectSpecularColor: {r: 0.44657826, g: 0.49641263, b: 0.57481676, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -1365,7 +1365,8 @@ MonoBehaviour:
   modelPositionSource: 0
   orienter: {fileID: 1591599745}
   propertyList: []
-  prefab_FeelerRay: {fileID: 1335525745713039694, guid: 498c830c5e5604e44b3788a7f47a4392, type: 3}
+  prefab_FeelerRay: {fileID: 1335525745713039694, guid: 498c830c5e5604e44b3788a7f47a4392,
+    type: 3}
   allowRotation: 0
 --- !u!135 &751649971
 SphereCollider:
@@ -2169,55 +2170,68 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1388726852}
     m_Modifications:
-    - target: {fileID: 33597107219087901, guid: 43511b9bc697510418bae74800f78728, type: 3}
+    - target: {fileID: 33597107219087901, guid: 43511b9bc697510418bae74800f78728,
+        type: 3}
       propertyPath: screenVerbosity
       value: 5
       objectReference: {fileID: 0}
-    - target: {fileID: 8428562094699281570, guid: 43511b9bc697510418bae74800f78728, type: 3}
+    - target: {fileID: 8428562094699281570, guid: 43511b9bc697510418bae74800f78728,
+        type: 3}
       propertyPath: m_Name
       value: Runtime Console
       objectReference: {fileID: 0}
-    - target: {fileID: 8428562094699281598, guid: 43511b9bc697510418bae74800f78728, type: 3}
+    - target: {fileID: 8428562094699281598, guid: 43511b9bc697510418bae74800f78728,
+        type: 3}
       propertyPath: m_RootOrder
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8428562094699281598, guid: 43511b9bc697510418bae74800f78728, type: 3}
+    - target: {fileID: 8428562094699281598, guid: 43511b9bc697510418bae74800f78728,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 8428562094699281598, guid: 43511b9bc697510418bae74800f78728, type: 3}
+    - target: {fileID: 8428562094699281598, guid: 43511b9bc697510418bae74800f78728,
+        type: 3}
       propertyPath: m_LocalPosition.y
       value: -1.5
       objectReference: {fileID: 0}
-    - target: {fileID: 8428562094699281598, guid: 43511b9bc697510418bae74800f78728, type: 3}
+    - target: {fileID: 8428562094699281598, guid: 43511b9bc697510418bae74800f78728,
+        type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8428562094699281598, guid: 43511b9bc697510418bae74800f78728, type: 3}
+    - target: {fileID: 8428562094699281598, guid: 43511b9bc697510418bae74800f78728,
+        type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8428562094699281598, guid: 43511b9bc697510418bae74800f78728, type: 3}
+    - target: {fileID: 8428562094699281598, guid: 43511b9bc697510418bae74800f78728,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 8428562094699281598, guid: 43511b9bc697510418bae74800f78728, type: 3}
+    - target: {fileID: 8428562094699281598, guid: 43511b9bc697510418bae74800f78728,
+        type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 8428562094699281598, guid: 43511b9bc697510418bae74800f78728, type: 3}
+    - target: {fileID: 8428562094699281598, guid: 43511b9bc697510418bae74800f78728,
+        type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 8428562094699281598, guid: 43511b9bc697510418bae74800f78728, type: 3}
+    - target: {fileID: 8428562094699281598, guid: 43511b9bc697510418bae74800f78728,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8428562094699281598, guid: 43511b9bc697510418bae74800f78728, type: 3}
+    - target: {fileID: 8428562094699281598, guid: 43511b9bc697510418bae74800f78728,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8428562094699281598, guid: 43511b9bc697510418bae74800f78728, type: 3}
+    - target: {fileID: 8428562094699281598, guid: 43511b9bc697510418bae74800f78728,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
@@ -2225,7 +2239,8 @@ PrefabInstance:
   m_SourcePrefab: {fileID: 100100000, guid: 43511b9bc697510418bae74800f78728, type: 3}
 --- !u!4 &975419021 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 8428562094699281598, guid: 43511b9bc697510418bae74800f78728, type: 3}
+  m_CorrespondingSourceObject: {fileID: 8428562094699281598, guid: 43511b9bc697510418bae74800f78728,
+    type: 3}
   m_PrefabInstance: {fileID: 975419020}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1026204641
@@ -2235,151 +2250,188 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 939451558721233786, guid: f3beab4d6d5f8fc4da73f13dec4e26a4, type: 3}
+    - target: {fileID: 939451558721233786, guid: f3beab4d6d5f8fc4da73f13dec4e26a4,
+        type: 3}
       propertyPath: m_Mesh
       value: 
       objectReference: {fileID: 0}
-    - target: {fileID: 939451558876913214, guid: f3beab4d6d5f8fc4da73f13dec4e26a4, type: 3}
+    - target: {fileID: 939451558876913214, guid: f3beab4d6d5f8fc4da73f13dec4e26a4,
+        type: 3}
       propertyPath: m_Mesh
       value: 
       objectReference: {fileID: 0}
-    - target: {fileID: 939451559928434029, guid: f3beab4d6d5f8fc4da73f13dec4e26a4, type: 3}
+    - target: {fileID: 939451559928434029, guid: f3beab4d6d5f8fc4da73f13dec4e26a4,
+        type: 3}
       propertyPath: m_Mesh
       value: 
       objectReference: {fileID: 0}
-    - target: {fileID: 939451560002694097, guid: f3beab4d6d5f8fc4da73f13dec4e26a4, type: 3}
+    - target: {fileID: 939451560002694097, guid: f3beab4d6d5f8fc4da73f13dec4e26a4,
+        type: 3}
       propertyPath: m_Mesh
       value: 
       objectReference: {fileID: 0}
-    - target: {fileID: 1414121021473090305, guid: f3beab4d6d5f8fc4da73f13dec4e26a4, type: 3}
+    - target: {fileID: 1414121021473090305, guid: f3beab4d6d5f8fc4da73f13dec4e26a4,
+        type: 3}
       propertyPath: m_RootOrder
       value: 6
       objectReference: {fileID: 0}
-    - target: {fileID: 1414121021473090305, guid: f3beab4d6d5f8fc4da73f13dec4e26a4, type: 3}
+    - target: {fileID: 1414121021473090305, guid: f3beab4d6d5f8fc4da73f13dec4e26a4,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1414121021473090305, guid: f3beab4d6d5f8fc4da73f13dec4e26a4, type: 3}
+    - target: {fileID: 1414121021473090305, guid: f3beab4d6d5f8fc4da73f13dec4e26a4,
+        type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1414121021473090305, guid: f3beab4d6d5f8fc4da73f13dec4e26a4, type: 3}
+    - target: {fileID: 1414121021473090305, guid: f3beab4d6d5f8fc4da73f13dec4e26a4,
+        type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1414121021473090305, guid: f3beab4d6d5f8fc4da73f13dec4e26a4, type: 3}
+    - target: {fileID: 1414121021473090305, guid: f3beab4d6d5f8fc4da73f13dec4e26a4,
+        type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1414121021473090305, guid: f3beab4d6d5f8fc4da73f13dec4e26a4, type: 3}
+    - target: {fileID: 1414121021473090305, guid: f3beab4d6d5f8fc4da73f13dec4e26a4,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1414121021473090305, guid: f3beab4d6d5f8fc4da73f13dec4e26a4, type: 3}
+    - target: {fileID: 1414121021473090305, guid: f3beab4d6d5f8fc4da73f13dec4e26a4,
+        type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1414121021473090305, guid: f3beab4d6d5f8fc4da73f13dec4e26a4, type: 3}
+    - target: {fileID: 1414121021473090305, guid: f3beab4d6d5f8fc4da73f13dec4e26a4,
+        type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1414121021473090305, guid: f3beab4d6d5f8fc4da73f13dec4e26a4, type: 3}
+    - target: {fileID: 1414121021473090305, guid: f3beab4d6d5f8fc4da73f13dec4e26a4,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1414121021473090305, guid: f3beab4d6d5f8fc4da73f13dec4e26a4, type: 3}
+    - target: {fileID: 1414121021473090305, guid: f3beab4d6d5f8fc4da73f13dec4e26a4,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1414121021473090305, guid: f3beab4d6d5f8fc4da73f13dec4e26a4, type: 3}
+    - target: {fileID: 1414121021473090305, guid: f3beab4d6d5f8fc4da73f13dec4e26a4,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1414121021473090307, guid: f3beab4d6d5f8fc4da73f13dec4e26a4, type: 3}
+    - target: {fileID: 1414121021473090307, guid: f3beab4d6d5f8fc4da73f13dec4e26a4,
+        type: 3}
       propertyPath: m_Name
       value: MenuSelector
       objectReference: {fileID: 0}
-    - target: {fileID: 1414121021555245180, guid: f3beab4d6d5f8fc4da73f13dec4e26a4, type: 3}
+    - target: {fileID: 1414121021555245180, guid: f3beab4d6d5f8fc4da73f13dec4e26a4,
+        type: 3}
       propertyPath: spacePinBinder
       value: 
       objectReference: {fileID: 1506107965}
-    - target: {fileID: 1414121021555245180, guid: f3beab4d6d5f8fc4da73f13dec4e26a4, type: 3}
+    - target: {fileID: 1414121021555245180, guid: f3beab4d6d5f8fc4da73f13dec4e26a4,
+        type: 3}
       propertyPath: spacePinBinderFile
       value: 
       objectReference: {fileID: 1506107967}
-    - target: {fileID: 1414121021967007561, guid: f3beab4d6d5f8fc4da73f13dec4e26a4, type: 3}
+    - target: {fileID: 1414121021967007561, guid: f3beab4d6d5f8fc4da73f13dec4e26a4,
+        type: 3}
       propertyPath: spacePinBinder
       value: 
       objectReference: {fileID: 1506107965}
-    - target: {fileID: 1414121021967007561, guid: f3beab4d6d5f8fc4da73f13dec4e26a4, type: 3}
+    - target: {fileID: 1414121021967007561, guid: f3beab4d6d5f8fc4da73f13dec4e26a4,
+        type: 3}
       propertyPath: spacePinBinderFile
       value: 
       objectReference: {fileID: 1506107967}
-    - target: {fileID: 1414121022593362633, guid: f3beab4d6d5f8fc4da73f13dec4e26a4, type: 3}
+    - target: {fileID: 1414121022593362633, guid: f3beab4d6d5f8fc4da73f13dec4e26a4,
+        type: 3}
       propertyPath: spacePinBinder
       value: 
       objectReference: {fileID: 1506107965}
-    - target: {fileID: 1414121022593362633, guid: f3beab4d6d5f8fc4da73f13dec4e26a4, type: 3}
+    - target: {fileID: 1414121022593362633, guid: f3beab4d6d5f8fc4da73f13dec4e26a4,
+        type: 3}
       propertyPath: spacePinBinderFile
       value: 
       objectReference: {fileID: 1506107967}
-    - target: {fileID: 1414121022816900935, guid: f3beab4d6d5f8fc4da73f13dec4e26a4, type: 3}
+    - target: {fileID: 1414121022816900935, guid: f3beab4d6d5f8fc4da73f13dec4e26a4,
+        type: 3}
       propertyPath: spacePinBinder
       value: 
       objectReference: {fileID: 1506107965}
-    - target: {fileID: 1414121022816900935, guid: f3beab4d6d5f8fc4da73f13dec4e26a4, type: 3}
+    - target: {fileID: 1414121022816900935, guid: f3beab4d6d5f8fc4da73f13dec4e26a4,
+        type: 3}
       propertyPath: spacePinBinderFile
       value: 
       objectReference: {fileID: 1506107967}
-    - target: {fileID: 1414121023006865963, guid: f3beab4d6d5f8fc4da73f13dec4e26a4, type: 3}
+    - target: {fileID: 1414121023006865963, guid: f3beab4d6d5f8fc4da73f13dec4e26a4,
+        type: 3}
       propertyPath: spacePinBinder
       value: 
       objectReference: {fileID: 1506107965}
-    - target: {fileID: 1414121023006865963, guid: f3beab4d6d5f8fc4da73f13dec4e26a4, type: 3}
+    - target: {fileID: 1414121023006865963, guid: f3beab4d6d5f8fc4da73f13dec4e26a4,
+        type: 3}
       propertyPath: spacePinBinderFile
       value: 
       objectReference: {fileID: 1506107967}
-    - target: {fileID: 2683675571349362001, guid: f3beab4d6d5f8fc4da73f13dec4e26a4, type: 3}
+    - target: {fileID: 2683675571349362001, guid: f3beab4d6d5f8fc4da73f13dec4e26a4,
+        type: 3}
       propertyPath: spacePinBinder
       value: 
       objectReference: {fileID: 1506107965}
-    - target: {fileID: 2683675571349362001, guid: f3beab4d6d5f8fc4da73f13dec4e26a4, type: 3}
+    - target: {fileID: 2683675571349362001, guid: f3beab4d6d5f8fc4da73f13dec4e26a4,
+        type: 3}
       propertyPath: spacePinBinderFile
       value: 
       objectReference: {fileID: 1506107967}
-    - target: {fileID: 4140586579816275308, guid: f3beab4d6d5f8fc4da73f13dec4e26a4, type: 3}
+    - target: {fileID: 4140586579816275308, guid: f3beab4d6d5f8fc4da73f13dec4e26a4,
+        type: 3}
       propertyPath: spacePinBinder
       value: 
       objectReference: {fileID: 1506107965}
-    - target: {fileID: 4140586579816275308, guid: f3beab4d6d5f8fc4da73f13dec4e26a4, type: 3}
+    - target: {fileID: 4140586579816275308, guid: f3beab4d6d5f8fc4da73f13dec4e26a4,
+        type: 3}
       propertyPath: spacePinBinderFile
       value: 
       objectReference: {fileID: 1506107967}
-    - target: {fileID: 6050181164527636157, guid: f3beab4d6d5f8fc4da73f13dec4e26a4, type: 3}
+    - target: {fileID: 6050181164527636157, guid: f3beab4d6d5f8fc4da73f13dec4e26a4,
+        type: 3}
       propertyPath: spacePinBinder
       value: 
       objectReference: {fileID: 1506107965}
-    - target: {fileID: 6050181164527636157, guid: f3beab4d6d5f8fc4da73f13dec4e26a4, type: 3}
+    - target: {fileID: 6050181164527636157, guid: f3beab4d6d5f8fc4da73f13dec4e26a4,
+        type: 3}
       propertyPath: spacePinBinderFile
       value: 
       objectReference: {fileID: 1506107967}
-    - target: {fileID: 6826779157959680795, guid: f3beab4d6d5f8fc4da73f13dec4e26a4, type: 3}
+    - target: {fileID: 6826779157959680795, guid: f3beab4d6d5f8fc4da73f13dec4e26a4,
+        type: 3}
       propertyPath: spacePinBinder
       value: 
       objectReference: {fileID: 1506107965}
-    - target: {fileID: 6826779157959680795, guid: f3beab4d6d5f8fc4da73f13dec4e26a4, type: 3}
+    - target: {fileID: 6826779157959680795, guid: f3beab4d6d5f8fc4da73f13dec4e26a4,
+        type: 3}
       propertyPath: spacePinBinderFile
       value: 
       objectReference: {fileID: 1506107967}
-    - target: {fileID: 8228581770698092589, guid: f3beab4d6d5f8fc4da73f13dec4e26a4, type: 3}
+    - target: {fileID: 8228581770698092589, guid: f3beab4d6d5f8fc4da73f13dec4e26a4,
+        type: 3}
       propertyPath: spacePinBinder
       value: 
       objectReference: {fileID: 1506107965}
-    - target: {fileID: 8228581770698092589, guid: f3beab4d6d5f8fc4da73f13dec4e26a4, type: 3}
+    - target: {fileID: 8228581770698092589, guid: f3beab4d6d5f8fc4da73f13dec4e26a4,
+        type: 3}
       propertyPath: spacePinBinderFile
       value: 
       objectReference: {fileID: 1506107967}
-    - target: {fileID: 8314732757775687893, guid: f3beab4d6d5f8fc4da73f13dec4e26a4, type: 3}
+    - target: {fileID: 8314732757775687893, guid: f3beab4d6d5f8fc4da73f13dec4e26a4,
+        type: 3}
       propertyPath: m_Mesh
       value: 
       objectReference: {fileID: 0}
@@ -2463,9 +2515,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 93bf53c0f434c774fae7087613e7f766, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Prefab_FrameViz: {fileID: 114836466068092498, guid: 14e05d2e3eab0df479903e125064ce4b, type: 3}
-  Prefab_SpongyAnchorViz: {fileID: 1510356976864930653, guid: b5ba1fa0f254af640a17dc22e4688b87, type: 3}
-  Prefab_FrozenAnchorViz: {fileID: 114965271361823434, guid: d47affea335f196479d4ec680aca4223, type: 3}
+  Prefab_FrameViz: {fileID: 114836466068092498, guid: 14e05d2e3eab0df479903e125064ce4b,
+    type: 3}
+  Prefab_SpongyAnchorViz: {fileID: 1510356976864930653, guid: b5ba1fa0f254af640a17dc22e4688b87,
+    type: 3}
+  Prefab_FrozenAnchorViz: {fileID: 114965271361823434, guid: d47affea335f196479d4ec680aca4223,
+    type: 3}
   connectingLine: {fileID: 2100000, guid: 0d9513524d19caa48a7071447d2cd84f, type: 2}
 --- !u!1 &1378325158
 GameObject:
@@ -2756,9 +2811,11 @@ MonoBehaviour:
   textVerticalOffset: -1.45
   wireFrameMaterial: {fileID: 2100000, guid: 30a725532743f544d8873fd08a9040bb, type: 2}
   meshMaterial: {fileID: 2100000, guid: e7629c5005d65c94ba769b3e2f1fe247, type: 2}
-  extrapolatedMeshMaterial: {fileID: 2100000, guid: 3cb6998e3870cb345a31ad89410518c1, type: 2}
+  extrapolatedMeshMaterial: {fileID: 2100000, guid: 3cb6998e3870cb345a31ad89410518c1,
+    type: 2}
   weightsMaterial: {fileID: 2100000, guid: 1e46624c9f6c5374da2204cd8c11e698, type: 2}
-  percentageWorldSpaceCanvasPrefab: {fileID: 3335127461111217805, guid: 20ac37323fee4694891b0de09cb74933, type: 3}
+  percentageWorldSpaceCanvasPrefab: {fileID: 3335127461111217805, guid: 20ac37323fee4694891b0de09cb74933,
+    type: 3}
   targetSubtree: {fileID: 0}
   isVisible: 1
 --- !u!1 &1485638433
@@ -3029,7 +3086,7 @@ MonoBehaviour:
   crUseGPS: 0
   crBeaconUuids: []
   anchorsParent: {fileID: 1506107964}
-  anchorsPrefab: {fileID: 3980099241396371023, guid: 345e9bf0df4b89442ac19a2d898daf38, type: 3}
+  anchorsPrefab: {fileID: 0}
   maxSearchSeconds: 45
   maxWaitForMoreAnchorsSeconds: 0.25
   minRecommendedForCreateProgress: 1
@@ -3074,7 +3131,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 83d9acc7968244a8886f3af591305bcb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  activeProfile: {fileID: 11400000, guid: 9f5b56c833066ac46bffd7280cd80b84, type: 2}
+  activeProfile: {fileID: 11400000, guid: b369bd81b384f994e87260826c6f2a6f, type: 2}
 --- !u!4 &1543370818
 Transform:
   m_ObjectHideFlags: 0
@@ -3353,7 +3410,8 @@ MonoBehaviour:
   modelPositionSource: 0
   orienter: {fileID: 1591599745}
   propertyList: []
-  prefab_FeelerRay: {fileID: 1335525745713039694, guid: 498c830c5e5604e44b3788a7f47a4392, type: 3}
+  prefab_FeelerRay: {fileID: 1335525745713039694, guid: 498c830c5e5604e44b3788a7f47a4392,
+    type: 3}
   allowRotation: 0
 --- !u!135 &2147212415
 SphereCollider:

--- a/Assets/WorldLocking.ASA/Scripts/PublisherASA.cs
+++ b/Assets/WorldLocking.ASA/Scripts/PublisherASA.cs
@@ -348,10 +348,13 @@ namespace Microsoft.MixedReality.WorldLocking.ASA
             asaManager.AnchorLocated += OnAnchorLocated;
             asaManager.LocateAnchorsCompleted += OnAnchorLocateCompleted;
 
+            int delayBeforeCreateMS = 1000;
+            await Task.Delay(delayBeforeCreateMS);
+
             Debug.Log($"To create session");
             await asaManager.CreateSessionAsync();
 
-            int delayBeforeStartMS = 3000;
+            int delayBeforeStartMS = 2000;
             await Task.Delay(delayBeforeStartMS);
 
             Debug.Log($"To start session");

--- a/Assets/WorldLocking.Core/Scripts/ARF/AnchorManagerARF.cs
+++ b/Assets/WorldLocking.Core/Scripts/ARF/AnchorManagerARF.cs
@@ -3,6 +3,10 @@
 
 #if UNITY_2020_1_OR_NEWER
 
+#if UNITY_2020_4_OR_NEWER
+#define WLT_ADD_ANCHOR_COMPONENT
+#endif // UNITY_2020_4_OR_NEWER
+
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -127,6 +131,14 @@ namespace Microsoft.MixedReality.WorldLocking.Core
             Debug.Log($"Creating anchor {id.FormatStr()}");
 #endif // WLT_EXTRA_LOGGING
             initialPose = AnchorFromSpongy.Multiply(initialPose);
+#if WLT_ADD_ANCHOR_COMPONENT
+            GameObject go = new GameObject(id.FormatStr());
+            go.transform.SetParent(parent);
+            go.transform.SetGlobalPose(initialPose);
+            go.AddComponent<ARAnchor>();
+            SpongyAnchorARF newAnchor = go.AddComponent<SpongyAnchorARF>();
+            return newAnchor;
+#else // WLT_ADD_ANCHOR_COMPONENT
             var arAnchor = arAnchorManager.AddAnchor(initialPose);
             if (arAnchor == null)
             {
@@ -136,6 +148,7 @@ namespace Microsoft.MixedReality.WorldLocking.Core
             arAnchor.gameObject.name = id.FormatStr();
             SpongyAnchorARF newAnchor =  arAnchor.gameObject.AddComponent<SpongyAnchorARF>();
             return newAnchor;
+#endif // WLT_ADD_ANCHOR_COMPONENT
         }
 
         protected override SpongyAnchor DestroyAnchor(AnchorId id, SpongyAnchor spongyAnchor)

--- a/Assets/WorldLocking.Core/Scripts/ARF/SpongyAnchorARF.cs
+++ b/Assets/WorldLocking.Core/Scripts/ARF/SpongyAnchorARF.cs
@@ -3,6 +3,10 @@
 
 #if UNITY_2020_1_OR_NEWER
 
+#if UNITY_2020_4_OR_NEWER
+#define WLT_ADD_ANCHOR_COMPONENT
+#endif // UNITY_2020_4_OR_NEWER
+
 using UnityEngine;
 #if WLT_ARFOUNDATION_PRESENT
 using UnityEngine.XR.ARFoundation;
@@ -122,11 +126,15 @@ namespace Microsoft.MixedReality.WorldLocking.Core
 #if WLT_ARFOUNDATION_PRESENT
         public void Cleanup(ARAnchorManager arAnchorManager)
         {
+#if WLT_ADD_ANCHOR_COMPONENT
+            GameObject.Destroy(gameObject);
+#else // WLT_ADD_ANCHOR_COMPONENT
             if ((arAnchorManager != null) && (arAnchor != null))
             {
                 arAnchorManager.RemoveAnchor(arAnchor);
                 arAnchor = null;
             }
+#endif // WLT_ADD_ANCHOR_COMPONENT
         }
 #endif // WLT_ARFOUNDATION_PRESENT
 

--- a/Assets/WorldLocking.Core/Scripts/WorldLockingManager.cs
+++ b/Assets/WorldLocking.Core/Scripts/WorldLockingManager.cs
@@ -29,7 +29,7 @@ namespace Microsoft.MixedReality.WorldLocking.Core
         /// allowing quick visual verification of the version of World Locking Tools for Unity currently installed.
         /// It has no effect in code, but serves only as a label.
         /// </summary>
-        public static string Version => "1.4.0";
+        public static string Version => "1.4.1";
 
         /// <summary>
         /// The configuration settings may only be set as a block.

--- a/DocGen/Documentation/HowTos/Samples/WLT_ASA_Sample.md
+++ b/DocGen/Documentation/HowTos/Samples/WLT_ASA_Sample.md
@@ -25,10 +25,10 @@ This sample provides assets and scripts to:
 
 This sample has been developed and tested using:
 
-* Unity 2020.3.2f1
-* Azure Spatial Anchors (ASA) v2.9.0
+* Unity 2020.3.8f1
+* Azure Spatial Anchors (ASA) v2.9.0 - v2.10.2.
 * Mixed Reality Toolkit v2.7.2
-* World Locking Tools for Unity v1.4.0
+* World Locking Tools for Unity v1.4.1
 * FrozenWorldEngine v1.1.1
 
 You can install WLT and this sample either from [WLT releases .unitypackage](https://github.com/microsoft/MixedReality-WorldLockingTools-Unity/releases) or from the Mixed Reality Feature Tool. Note that if installing from the FeatureTool, you must not only install the WLT Examples dependency (automatic), but also Import the Examples into your project. See [Installing WLT from MR Feature Tool](../WLTviaMRFeatureTool.md) for details.

--- a/UPM/asa_files/CHANGELOG.md
+++ b/UPM/asa_files/CHANGELOG.md
@@ -2,4 +2,6 @@
 
 [See release notes](https://github.com/microsoft/MixedReality-WorldLockingTools-Unity/releases)
 
+## 1.4.1 - Workaround for OpenXR session tracking state issue.
+
 ## 1.4.0 - Initial release

--- a/UPM/asa_files/package.json
+++ b/UPM/asa_files/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.microsoft.mixedreality.wlt.asa",
   "displayName": "WLT-ASA",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "unity": "2020.3",
   "msftFeatureCategory": "World Locking Tools",
   "description": "World Locking Tools for Unity (WLT) + Azure Spatial Anchors (ASA)\n\nThis optional add-on to WLT leverages ASA to persist coordinate spaces across sessions and share them across devices.\nCross platform support includes HoloLens, Android, and iOS.",
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "com.microsoft.azure.spatial-anchors-sdk.core": "2.9.0",
-    "com.microsoft.mixedreality.worldlockingtools": "1.4.0"
+    "com.microsoft.mixedreality.worldlockingtools": "1.4.1"
   },
   "files": [
     "WorldLocking.ASA",

--- a/UPM/asa_samples_files/CHANGELOG.md
+++ b/UPM/asa_samples_files/CHANGELOG.md
@@ -2,4 +2,6 @@
 
 [See release notes](https://github.com/microsoft/MixedReality-WorldLockingTools-Unity/releases)
 
+## 1.4.1 - Workaround for OpenXR session tracking state issue.
+
 ## 1.4.0 - Initial release

--- a/UPM/asa_samples_files/package.json
+++ b/UPM/asa_samples_files/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.microsoft.mixedreality.wlt.asa.samples",
   "displayName": "WLT-ASA Samples",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "unity": "2020.3",
   "msftFeatureCategory" : "World Locking Tools",
   "description": "Example scenes and scripts leveraging Azure Space Anchors (ASA) to persist World Locked coordinate spaces across sessions and share across devices.\n\nFurther samples available at\nhttps://microsoft.github.io/MixedReality-WorldLockingTools-Samples/README.html",
@@ -36,9 +36,9 @@
   "dependencies": {
     "com.microsoft.azure.spatial-anchors-sdk.core": "2.9.0",
     "com.microsoft.mixedreality.toolkit.foundation": "2.7.0",
-    "com.microsoft.mixedreality.wlt.asa": "1.4.0",
-    "com.microsoft.mixedreality.worldlockingtools": "1.4.0",
-    "com.microsoft.mixedreality.worldlockingsamples": "1.4.0"
+    "com.microsoft.mixedreality.wlt.asa": "1.4.1",
+    "com.microsoft.mixedreality.worldlockingtools": "1.4.1",
+    "com.microsoft.mixedreality.worldlockingsamples": "1.4.1"
   },
   "files": [
     "package.json.meta",

--- a/UPM/core_files/CHANGELOG.md
+++ b/UPM/core_files/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [See release notes](https://github.com/microsoft/MixedReality-WorldLockingTools-Unity/releases)
 
+## 1.4.1 - Workaround for OpenXR tracking state issue.
+
 ## 1.4.0 - Optional integration of Azure Spatial Anchors for persistence and sharing.
 
 ## 1.3.5 - Automated setup from MRTK Unity menu.

--- a/UPM/core_files/package.json
+++ b/UPM/core_files/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.microsoft.mixedreality.worldlockingtools",
   "displayName": "WLT Core",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "unity": "2019.4",
   "msftFeatureCategory" : "World Locking Tools",
   "description": "World Locking Tools for Unity (WLT)\n\nLock AR virtual space to physical space automatically and intuitively, without requiring application management of anchors.\nPreserve object relative layout, while remaining perceptually stationary in the physical world.",

--- a/UPM/samples_files/CHANGELOG.md
+++ b/UPM/samples_files/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [See release notes](https://github.com/microsoft/MixedReality-WorldLockingTools-Unity/releases)
 
+## 1.4.1 - Workaround for OpenXR session tracking state issue.
+
 ## 1.4.0 - Optional integration of Azure Spatial Anchors for persistence and sharing.
 
 ## 1.3.5 - Dependency on WLT v1.3.5 for automated setup tools.

--- a/UPM/samples_files/package.json
+++ b/UPM/samples_files/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.microsoft.mixedreality.worldlockingsamples",
   "displayName": "WLT Samples",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "unity": "2019.4",
   "msftFeatureCategory" : "World Locking Tools",
   "description": "Basic examples for World Locking Tools.\n\nFurther samples available at\nhttps://microsoft.github.io/MixedReality-WorldLockingTools-Samples/README.html",
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "com.microsoft.mixedreality.toolkit.foundation": "2.7.0",
-    "com.microsoft.mixedreality.worldlockingtools": "1.4.0"
+    "com.microsoft.mixedreality.worldlockingtools": "1.4.1"
   },
   "files": [
     "package.json.meta",


### PR DESCRIPTION
OpenXR is now returning a session subsystem, but the session always (incorrectly) reports tracking state = TrackingState.None. 

Previous OpenXR issue was that no session subsystem was found.

Workaround is to leave session subsystem null, which will ignore its (incorrect) tracking state.

Additionally, this PR includes a workaround for a race condition caused by recent changes in ASA.

Also includes use of new API for creating anchors within the AR Foundation framework.