### PR TITLE
Adjust for OpenXR session subsystems special needs.

### DIFF
--- a/Assets/WorldLocking.Core/Scripts/AnchorManager.cs
+++ b/Assets/WorldLocking.Core/Scripts/AnchorManager.cs
@@ -382,7 +382,7 @@ namespace Microsoft.MixedReality.WorldLocking.Core
 
         private bool LostTrackingCleanup(string message)
         {
-            Debug.Log($"Lost Tracking Frame {Time.frameCount}");
+            Debug.Log($"{message} Frame {Time.frameCount}");
             lastTrackingInactiveTime = Time.unscaledTime;
 
             if (newSpongyAnchor)

--- a/Assets/WorldLocking.Core/Scripts/WorldLockingManager.cs
+++ b/Assets/WorldLocking.Core/Scripts/WorldLockingManager.cs
@@ -29,7 +29,7 @@ namespace Microsoft.MixedReality.WorldLocking.Core
         /// allowing quick visual verification of the version of World Locking Tools for Unity currently installed.
         /// It has no effect in code, but serves only as a label.
         /// </summary>
-        public static string Version => "1.4.2";
+        public static string Version => "1.4.3";
 
         /// <summary>
         /// The configuration settings may only be set as a block.

--- a/Assets/WorldLocking.Core/Scripts/XR/AnchorManagerXR.cs
+++ b/Assets/WorldLocking.Core/Scripts/XR/AnchorManagerXR.cs
@@ -78,12 +78,6 @@ namespace Microsoft.MixedReality.WorldLocking.Core
             }
 
             var session = FindSessionSubsystem();
-            /// mafinc - Currently a problem in OpenXR obtaining the session subsystem.
-            /// Everything can function without it, it is only used for detecting loss of tracking.
-            //if (session == null)
-            //{
-            //    return null;
-            //}
 
             AnchorManagerXR anchorManager = new AnchorManagerXR(plugin, headTracker, xrAnchorManager, session);
 
@@ -150,17 +144,6 @@ namespace Microsoft.MixedReality.WorldLocking.Core
         /// </remarks>
         private static XRSessionSubsystem FindSessionSubsystem()
         {
-#if WLT_XR_MANAGEMENT_PRESENT
-            /// Workaround. OpenXR is now returning a SessionSubsystem, but it is reporting 
-            /// its trackingStatus as TrackingStatus.None forever. Since the (incorrect) tracking status
-            /// is all we want the XRSessionSubsystem for, leave it as null for now.
-            bool isOpenXR = XRGeneralSettings.Instance.Manager.activeLoader.name.StartsWith("Open XR");
-            if (isOpenXR)
-            {
-                return null;
-            }
-#endif // WLT_XR_MANAGEMENT_PRESENT
-
             List<XRSessionSubsystem> sessionSubsystems = new List<XRSessionSubsystem>();
             SubsystemManager.GetInstances(sessionSubsystems);
             Debug.Log($"Found {sessionSubsystems.Count} session subsystems");
@@ -205,7 +188,7 @@ namespace Microsoft.MixedReality.WorldLocking.Core
         {
             this.xrAnchorManager = xrAnchorManager;
             this.sessionSubsystem = session;
-            Debug.Log($"XR: Created AnchorManager XR, xrMgr={(this.xrAnchorManager != null ? "good" : "null")}");
+            Debug.Log($"XR: Created AnchorManager XR, xrMgr={(this.xrAnchorManager != null ? "good" : "null")} session={(session != null ? "good" : "null")}");
 
             Debug.Log($"ActiveLoader name:[{XRGeneralSettings.Instance.Manager.activeLoader.name}] type:[{XRGeneralSettings.Instance.Manager.activeLoader.GetType().FullName}]");
 
@@ -230,6 +213,14 @@ namespace Microsoft.MixedReality.WorldLocking.Core
             if (xrAnchorManager == null)
             {
                 return false;
+            }
+            if (sessionSubsystem != null)
+            {
+                sessionSubsystem.Update(new XRSessionUpdateParams
+                {
+                    screenOrientation = Screen.orientation,
+                    screenDimensions = new Vector2Int(Screen.width, Screen.height)
+                });
             }
             DebugLogExtra($"UpdateTrackables {Time.frameCount} XRAnchorSubsystem is {xrAnchorManager.running}");
             TrackableChanges<XRAnchor> changes = xrAnchorManager.GetChanges(Unity.Collections.Allocator.Temp);
@@ -343,16 +334,36 @@ namespace Microsoft.MixedReality.WorldLocking.Core
 
         protected override bool IsTracking()
         {
-            /// Currently a problem obtaining the sessionSubsystem in OpenXR. Until that is remediated,
-            /// we will assume that if we have no sessionSubsystem, then tracking is fine.
-            if (sessionSubsystem == null)
+            DebugLogExtra($"AMXR F{Time.frameCount} session running={sessionSubsystem.running} state={sessionSubsystem.trackingState}");
+            if (!sessionSubsystem.running)
             {
+                // This is probably a catastrophic failure case.
+                DebugLogExtra($"LostTracking: Have session subsystem but not running.");
+                return false;
+            }
+            if (sessionSubsystem.trackingState == TrackingState.Tracking)
+            {
+                // Something we can all agree on. If trackingState is Tracking, device is tracking.
                 return true;
             }
-            //Debug.Log($"AMXR F{Time.frameCount} session running={sessionSubsystem.running} state={sessionSubsystem.trackingState}");
-            return sessionSubsystem != null
-                && sessionSubsystem.running
-                && sessionSubsystem.trackingState != TrackingState.None;
+            if (sessionSubsystem.trackingState == TrackingState.None)
+            {
+                // Another thing we all agree on. If trackingState is None, there is no tracking.
+                return false;
+            }
+            // Then trackingState is TrackingState.Limited. There seems to be no agreement on what that means.
+            if (openXRPersistence)
+            {
+                // If you put a blanket over your head, OpenXR calls that tracking state "Limited".
+                return false;
+            }
+#if UNITY_ANDROID || UNITY_IOS
+            // On mobile, loss of tracking goes to trackingState==TrackingState.Limited
+            return false;
+#else // last case is WMR XR Plugin
+            // WMR XR Plugin only ever returns None (not tracking) or Limited (is tracking).
+            return true;
+#endif // WMR XR Plugin
         }
 
         protected override SpongyAnchor CreateAnchor(AnchorId id, Transform parent, Pose initialPose)

--- a/Assets/WorldLocking.Core/Scripts/XR/AnchorManagerXR.cs
+++ b/Assets/WorldLocking.Core/Scripts/XR/AnchorManagerXR.cs
@@ -334,36 +334,19 @@ namespace Microsoft.MixedReality.WorldLocking.Core
 
         protected override bool IsTracking()
         {
+            if (sessionSubsystem == null)
+            {
+                Debug.LogError($"Frame={Time.frameCount} have null sessionSubsystem.");
+                return false;
+            }
             DebugLogExtra($"AMXR F{Time.frameCount} session running={sessionSubsystem.running} state={sessionSubsystem.trackingState}");
             if (!sessionSubsystem.running)
             {
                 // This is probably a catastrophic failure case.
-                DebugLogExtra($"LostTracking: Have session subsystem but not running.");
+                Debug.Log($"Frame={Time.frameCount} LostTracking: Have session subsystem but not running.");
                 return false;
             }
-            if (sessionSubsystem.trackingState == TrackingState.Tracking)
-            {
-                // Something we can all agree on. If trackingState is Tracking, device is tracking.
-                return true;
-            }
-            if (sessionSubsystem.trackingState == TrackingState.None)
-            {
-                // Another thing we all agree on. If trackingState is None, there is no tracking.
-                return false;
-            }
-            // Then trackingState is TrackingState.Limited. There seems to be no agreement on what that means.
-            if (openXRPersistence)
-            {
-                // If you put a blanket over your head, OpenXR calls that tracking state "Limited".
-                return false;
-            }
-#if UNITY_ANDROID || UNITY_IOS
-            // On mobile, loss of tracking goes to trackingState==TrackingState.Limited
-            return false;
-#else // last case is WMR XR Plugin
-            // WMR XR Plugin only ever returns None (not tracking) or Limited (is tracking).
-            return true;
-#endif // WMR XR Plugin
+            return sessionSubsystem.notTrackingReason == NotTrackingReason.None;
         }
 
         protected override SpongyAnchor CreateAnchor(AnchorId id, Transform parent, Pose initialPose)


### PR DESCRIPTION
The MR OpenXR session subsystem needs to be updated externally. The ARSession component performs this manual pumping of the subsystem in its monobehavior Update() function.

When not using ARFoundation, however, subsystems with Update functions must be updated by some other agent. Some of them are updated by MRTK, but not the XRSessionSubsystem.

The WMR XR Plugin doesn't seem to require this update. It is difficult to say whether the mobile platforms require it, as MRTK adds some AR Foundation elements to get mobile to work. If the Update is redundant, it doesn't seem to hurt anything in tests so far.

If it does, then we might need to push responsibility onto the application, either requiring them to call XRSessionSubsystem.Update() when appropriate, or adding a checkbox letting them tell WLT whether or not it needs to call the Update(). But that would be a last resort, because they application developer has no better way of knowing whether to call Update on the session subsystem than we do.