### PR TITLE
Support local world locking

### DIFF
--- a/Assets/WorldLocking.Core/Editor/WorldLockingContextEditor.cs
+++ b/Assets/WorldLocking.Core/Editor/WorldLockingContextEditor.cs
@@ -76,6 +76,8 @@ namespace Microsoft.MixedReality.WorldLocking.Core
                 {
                     using (new EditorGUI.IndentLevelScope())
                     {
+                        AddProperty(mgrPath, "applyAdjustment");
+
                         AddProperty(mgrPath, "AdjustmentFrame");
 
                         AddProperty(mgrPath, "CameraParent");

--- a/Assets/WorldLocking.Core/Scripts/IOrienter.cs
+++ b/Assets/WorldLocking.Core/Scripts/IOrienter.cs
@@ -50,6 +50,14 @@ namespace Microsoft.MixedReality.WorldLocking.Core
     public interface IOrienter
     {
         /// <summary>
+        /// Optional subtree alignment manager. 
+        /// </summary>
+        /// <remarks>
+        /// If unset, will use global alignment manager, ie WorldLockingManager.GetInstance().AlignmentManager.
+        /// </remarks>
+        IAlignmentManager AlignmentManager { get; set; }
+
+        /// <summary>
         /// Add this orientable to the list to be both source of rotation computation, and targets to apply the computed rotation.
         /// </summary>
         /// <param name="orientable">The object to start maintining the orientation of.</param>

--- a/Assets/WorldLocking.Core/Scripts/LinkageSettings.cs
+++ b/Assets/WorldLocking.Core/Scripts/LinkageSettings.cs
@@ -37,6 +37,19 @@ namespace Microsoft.MixedReality.WorldLocking.Core
             }
         }
 
+        [SerializeField]
+        [Tooltip("Apply world locking adjustment to the AdjustmentFrame.")]
+        private bool applyAdjustment;
+
+        /// <summary>
+        /// Apply world locking adjustment to the AdjustmentFrame.
+        /// </summary>
+        /// <remarks>
+        /// If this is false, then it is up to the application to apply the correction.
+        /// This allows the correction to be applied selectively to subsets of the scene hierarchy.
+        /// </remarks>
+        public bool ApplyAdjustment { get { return applyAdjustment; } set { applyAdjustment = value; } }
+
         /// <summary>
         /// The transform at which to apply the camera adjustment. This can't be the camera node, as its
         /// transform is overwritten every frame with head pose data. But the camera should be an attached
@@ -58,6 +71,7 @@ namespace Microsoft.MixedReality.WorldLocking.Core
         /// </summary>
         public void InitToDefaults()
         {
+            ApplyAdjustment = true;
             AdjustmentFrame = null;
             CameraParent = null;
         }

--- a/Assets/WorldLocking.Core/Scripts/SpacePin.cs
+++ b/Assets/WorldLocking.Core/Scripts/SpacePin.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+//#define WLT_LOG_SAVE_LOAD
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -91,6 +93,7 @@ namespace Microsoft.MixedReality.WorldLocking.Core
             {
                 if (alignmentManager != value)
                 {
+                    DebugLogSaveLoad($"Changing {name} pin's alignmentmanager {(value == WorldLockingManager.GetInstance().AlignmentManager ? "to global" : "from global")}");
                     Reset();
                     if (alignmentManager != null)
                     {
@@ -191,6 +194,12 @@ namespace Microsoft.MixedReality.WorldLocking.Core
             }
         }
 
+        private void DebugLogSaveLoad(string message)
+        {
+#if WLT_LOG_SAVE_LOAD
+            Debug.Log($"F={Time.frameCount} {message}");
+#endif // WLT_LOG_SAVE_LOAD
+        }
         private void CheckDependencies()
         {
             /// Cache the WorldLockingManager as a dependency.
@@ -198,6 +207,7 @@ namespace Microsoft.MixedReality.WorldLocking.Core
 
             if (AlignmentManager == null)
             {
+                DebugLogSaveLoad($"Setting {name} pin's alignment manager to global because unset.");
                 AlignmentManager = manager.AlignmentManager;
             }
         }
@@ -251,6 +261,8 @@ namespace Microsoft.MixedReality.WorldLocking.Core
         public virtual void SetLockedPose(Pose lockedPose)
         {
             this.lockedPose = lockedPose;
+
+            DebugLogSaveLoad($"SetLockedPose {name}: mgr={(AlignmentManager == WorldLockingManager.GetInstance().AlignmentManager ? "global" : "local")}");
 
             PushAlignmentData(AlignmentManager);
 

--- a/Assets/WorldLocking.Core/Scripts/SpacePinOrientable.cs
+++ b/Assets/WorldLocking.Core/Scripts/SpacePinOrientable.cs
@@ -82,6 +82,7 @@ namespace Microsoft.MixedReality.WorldLocking.Core
         /// <param name="lockedRotation">The new world locked rotation to adopt.</param>
         public void PushRotation(IAlignmentManager mgr, Quaternion lockedRotation)
         {
+            //Debug.Log($"PushRotation {name}: mgr={(mgr == WorldLockingManager.GetInstance().AlignmentManager ? "global" : "local")}");
             /// Append the modeling pose rotation. This will cancel out when computing the 
             /// pinnedFromLocked transform, so that the computed rotation gets applied as is.
             LockedPose = new Pose(LockedPose.position, lockedRotation * ModelingPoseGlobal.rotation);

--- a/Assets/WorldLocking.Examples/Scripts/SpacePinManipulation.cs
+++ b/Assets/WorldLocking.Examples/Scripts/SpacePinManipulation.cs
@@ -78,7 +78,14 @@ namespace Microsoft.MixedReality.WorldLocking.Examples
         /// </summary>
         private void OnFinishManipulation()
         {
-            SetFrozenPose(ExtractModelPose());
+            if (WorldLockingManager.GetInstance().ApplyAdjustment)
+            {
+                SetFrozenPose(ExtractModelPose());
+            }
+            else
+            {
+                SetSpongyPose(ExtractModelPose());
+            }
         }
 
         #endregion Manipulation callback

--- a/Assets/WorldLocking.Examples/Scripts/SpacePinOrientableManipulation.cs
+++ b/Assets/WorldLocking.Examples/Scripts/SpacePinOrientableManipulation.cs
@@ -87,7 +87,14 @@ namespace Microsoft.MixedReality.WorldLocking.Examples
         /// </summary>
         private void OnFinishManipulation()
         {
-            SetFrozenPose(ExtractModelPose());
+            if (WorldLockingManager.GetInstance().ApplyAdjustment)
+            {
+                SetFrozenPose(ExtractModelPose());
+            }
+            else
+            {
+                SetSpongyPose(ExtractModelPose());
+            }
         }
     }
 }

--- a/Assets/WorldLocking.Tools/Editor/WorldLockingSetup.cs
+++ b/Assets/WorldLocking.Tools/Editor/WorldLockingSetup.cs
@@ -116,6 +116,11 @@ namespace Microsoft.MixedReality.WorldLocking.Tools
                 Debug.Log($"Scene has no main camera, camera linkage will not be configured.");
                 return;
             }
+            if (!worldLockingContext.SharedSettings.linkageSettings.ApplyAdjustment)
+            {
+                Debug.Log($"System application of world locking adjustments is disabled. Ignoring camera linkage.");
+                return;
+            }
             Transform mainCamera = Camera.main.transform;
 
             // If the camera doesn't have a parent

--- a/Assets/WorldLocking.Tools/Scripts/AnchorGraphVisual.cs
+++ b/Assets/WorldLocking.Tools/Scripts/AnchorGraphVisual.cs
@@ -219,9 +219,9 @@ namespace Microsoft.MixedReality.WorldLocking.Tools
             UpdateFragmentVisuals();
 
             /// The "frozen" coordinates here are ignoring the rest of the transform up the camera tree.
-            Pose frozenFromLocked = manager.FrozenFromLocked;
+            Pose globalFromLocked = manager.ApplyAdjustment ? manager.FrozenFromLocked : manager.SpongyFromLocked;
 
-            var frozenCreator = new FrozenAnchorVisualCreator(Prefab_FrozenAnchorViz, frozenFragmentVizs, frozenFromLocked);
+            var frozenCreator = new FrozenAnchorVisualCreator(Prefab_FrozenAnchorViz, frozenFragmentVizs, globalFromLocked);
             ResourceMirror.Sync(
                 frozenItems,
                 frozenResources,

--- a/UPM/asa_files/CHANGELOG.md
+++ b/UPM/asa_files/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [See release notes](https://github.com/microsoft/MixedReality-WorldLockingTools-Unity/releases)
 
+## 1.5.0 - WLT can be limited to subgraph in scene hierarchy.
+
 ## 1.4.2 - Support persistence using AR Foundation/OpenXR.
 
 ## 1.4.1 - Workaround for OpenXR session tracking state issue.

--- a/UPM/asa_files/package.json
+++ b/UPM/asa_files/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.microsoft.mixedreality.wlt.asa",
   "displayName": "WLT-ASA",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "unity": "2020.3",
   "msftFeatureCategory": "World Locking Tools",
   "description": "World Locking Tools for Unity (WLT) + Azure Spatial Anchors (ASA)\n\nThis optional add-on to WLT leverages ASA to persist coordinate spaces across sessions and share them across devices.\nCross platform support includes HoloLens, Android, and iOS.",
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "com.microsoft.azure.spatial-anchors-sdk.core": "2.9.0",
-    "com.microsoft.mixedreality.worldlockingtools": "1.4.2"
+    "com.microsoft.mixedreality.worldlockingtools": "1.5.0"
   },
   "files": [
     "WorldLocking.ASA",

--- a/UPM/asa_samples_files/CHANGELOG.md
+++ b/UPM/asa_samples_files/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [See release notes](https://github.com/microsoft/MixedReality-WorldLockingTools-Unity/releases)
 
+## 1.5.0 - WLT can be limited to subgraph in scene hierarchy.
+
 ## 1.4.2 - Support persistence using AR Foundation/OpenXR.
 
 ## 1.4.1 - Workaround for OpenXR session tracking state issue.

--- a/UPM/asa_samples_files/package.json
+++ b/UPM/asa_samples_files/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.microsoft.mixedreality.wlt.asa.samples",
   "displayName": "WLT-ASA Samples",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "unity": "2020.3",
   "msftFeatureCategory" : "World Locking Tools",
   "description": "Example scenes and scripts leveraging Azure Space Anchors (ASA) to persist World Locked coordinate spaces across sessions and share across devices.\n\nFurther samples available at\nhttps://microsoft.github.io/MixedReality-WorldLockingTools-Samples/README.html",
@@ -36,9 +36,9 @@
   "dependencies": {
     "com.microsoft.azure.spatial-anchors-sdk.core": "2.9.0",
     "com.microsoft.mixedreality.toolkit.foundation": "2.7.0",
-    "com.microsoft.mixedreality.wlt.asa": "1.4.2",
-    "com.microsoft.mixedreality.worldlockingtools": "1.4.2",
-    "com.microsoft.mixedreality.worldlockingsamples": "1.4.2"
+    "com.microsoft.mixedreality.wlt.asa": "1.5.0",
+    "com.microsoft.mixedreality.worldlockingtools": "1.5.0",
+    "com.microsoft.mixedreality.worldlockingsamples": "1.5.0"
   },
   "files": [
     "package.json.meta",

--- a/UPM/core_files/CHANGELOG.md
+++ b/UPM/core_files/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [See release notes](https://github.com/microsoft/MixedReality-WorldLockingTools-Unity/releases)
 
+## 1.5.0 - WLT can be limited to subgraph in scene hierarchy.
+
 ## 1.4.2 - Support persistence using AR Foundation/OpenXR.
 
 ## 1.4.1 - Workaround for OpenXR tracking state issue.

--- a/UPM/core_files/package.json
+++ b/UPM/core_files/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.microsoft.mixedreality.worldlockingtools",
   "displayName": "WLT Core",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "unity": "2019.4",
   "msftFeatureCategory" : "World Locking Tools",
   "description": "World Locking Tools for Unity (WLT)\n\nLock AR virtual space to physical space automatically and intuitively, without requiring application management of anchors.\nPreserve object relative layout, while remaining perceptually stationary in the physical world.",

--- a/UPM/samples_files/CHANGELOG.md
+++ b/UPM/samples_files/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [See release notes](https://github.com/microsoft/MixedReality-WorldLockingTools-Unity/releases)
 
+## 1.5.0 - WLT can be limited to subgraph in scene hierarchy.
+
 ## 1.4.2 - Support persistence using AR Foundation/OpenXR.
 
 ## 1.4.1 - Workaround for OpenXR session tracking state issue.

--- a/UPM/samples_files/package.json
+++ b/UPM/samples_files/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.microsoft.mixedreality.worldlockingsamples",
   "displayName": "WLT Samples",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "unity": "2019.4",
   "msftFeatureCategory" : "World Locking Tools",
   "description": "Basic examples for World Locking Tools.\n\nFurther samples available at\nhttps://microsoft.github.io/MixedReality-WorldLockingTools-Samples/README.html",
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "com.microsoft.mixedreality.toolkit.foundation": "2.7.0",
-    "com.microsoft.mixedreality.worldlockingtools": "1.4.2"
+    "com.microsoft.mixedreality.worldlockingtools": "1.5.0"
   },
   "files": [
     "package.json.meta",

--- a/UPM/upm_pack.cmd
+++ b/UPM/upm_pack.cmd
@@ -3,6 +3,11 @@ rem Simple script to create NPM packages suitable for Unity.
 rem Does NOT publish the packages, they will be left in Assets folder.
 rem NOTE: Unity must be run on the project at least once, to ensure all
 rem necessary .meta files are present.
+rem
+rem Before running this script, go through all of the folders in .\UPM
+rem and update at least:
+rem CHANGELOG.md - what is new version and what is special about it. 
+rem package.json - update target version and version dependencies.
 rem 
 rem Run this script from project's .\UPM folder (where it exists).
 rem 
@@ -11,7 +16,7 @@ rem After each packaging, inspect the results in the spawned window.
 rem If results look good, close the window (enter "exit") to proceed to next package.
 rem
 rem After creating and verifying both packages, from command prompt go to Assets folder,
-rem and run 
+rem and, for each .tgz package generated, run 
 rem    'npm publish com.microsoft.mixedreality.worldlockingtools-1.2.3.tgz'
 rem and 
 rem    'npm publish com.microsoft.mixedreality.worldlockingsamples-1.2.3.tgz'


### PR DESCRIPTION
Allow the restriction of world locking to local subtrees, while still getting full world locking.

While some benefits of WLT will be unavailable (e.g. world locking of non-movable items such as particle systems, nav meshes, etc), this allows parts of an application to gain benefits of world locking without restructuring other parts.

For new projects, it is still strong recommended to apply WLT globally, along with possible additional pinning of subtrees.

Fixes #201 