### PR TITLE
Backward compat for Unity 2018 .NET backend

### DIFF
--- a/Assets/WorldLocking.ASA/Scripts/PublisherASA.cs
+++ b/Assets/WorldLocking.ASA/Scripts/PublisherASA.cs
@@ -1341,6 +1341,7 @@ namespace Microsoft.MixedReality.WorldLocking.ASA
         {
             Debug.Assert(record.cloudAnchor != null, $"Trying to create native resources from a null cloud anchor");
             var wltMgr = WorldLockingManager.GetInstance();
+            await Task.Yield();
 #if UNITY_WSA
             Pose spongyPose = record.cloudAnchor.GetPose();
             var lockedPose = wltMgr.LockedFromSpongy.Multiply(spongyPose);

--- a/Assets/WorldLocking.ASA/Scripts/SpacePinBinderFile.cs
+++ b/Assets/WorldLocking.ASA/Scripts/SpacePinBinderFile.cs
@@ -66,7 +66,7 @@ namespace Microsoft.MixedReality.WorldLocking.ASA
                 return false;
             }
             var bindings = binder.GetBindings();
-            using FileStream fileStream = new FileStream(GetFullPath(), FileMode.Create);
+            using (FileStream fileStream = new FileStream(GetFullPath(), FileMode.Create))
             {
                 using (StreamWriter writer = new StreamWriter(fileStream))
                 {

--- a/Assets/WorldLocking.ASA/Scripts/SpacePinBinderFile.cs
+++ b/Assets/WorldLocking.ASA/Scripts/SpacePinBinderFile.cs
@@ -66,12 +66,15 @@ namespace Microsoft.MixedReality.WorldLocking.ASA
                 return false;
             }
             var bindings = binder.GetBindings();
-            using (StreamWriter writer = new StreamWriter(new FileStream(GetFullPath(), FileMode.Create)))
+            using FileStream fileStream = new FileStream(GetFullPath(), FileMode.Create);
             {
-                writer.WriteLine($"{binderKey}{binder.Name}");
-                foreach (var binding in bindings)
+                using (StreamWriter writer = new StreamWriter(fileStream))
                 {
-                    writer.WriteLine($"{binding.spacePinId}, {binding.cloudAnchorId}");
+                    writer.WriteLine($"{binderKey}{binder.Name}");
+                    foreach (var binding in bindings)
+                    {
+                        writer.WriteLine($"{binding.spacePinId}, {binding.cloudAnchorId}");
+                    }
                 }
             }
             return true;
@@ -95,25 +98,28 @@ namespace Microsoft.MixedReality.WorldLocking.ASA
                 Debug.LogError($"{name} can't find file {fullPath}");
                 return false;
             }
-            using (StreamReader reader = new StreamReader(new FileStream(GetFullPath(), FileMode.Open)))
+            using (FileStream fileStream = new FileStream(GetFullPath(), FileMode.Open, FileAccess.Read))
             {
-                string line = reader.ReadLine();
-                while (line != null)
+                using (StreamReader reader = new StreamReader(fileStream))
                 {
-                    string binderName = line.Replace(binderKey, "");
-                    bool isCorrectBinder = binderName == binder.Name;
-                    Tools.SimpleConsole.AddLine(8, $"Got:{binderName}, Want:{binder.Name}, Math={isCorrectBinder}");
-                    char[] separators = new char[] { ' ', ',' };
-                    while ((line = reader.ReadLine()) != null)
+                    string line = reader.ReadLine();
+                    while (line != null)
                     {
-                        if (line.StartsWith(binderKey))
+                        string binderName = line.Replace(binderKey, "");
+                        bool isCorrectBinder = binderName == binder.Name;
+                        Tools.SimpleConsole.AddLine(8, $"Got:{binderName}, Want:{binder.Name}, Math={isCorrectBinder}");
+                        char[] separators = new char[] { ' ', ',' };
+                        while ((line = reader.ReadLine()) != null)
                         {
-                            break;
-                        }
-                        if (isCorrectBinder)
-                        {
-                            string[] tokens = line.Split(separators, System.StringSplitOptions.RemoveEmptyEntries);
-                            binder.CreateBinding(tokens[0], tokens[1]);
+                            if (line.StartsWith(binderKey))
+                            {
+                                break;
+                            }
+                            if (isCorrectBinder)
+                            {
+                                string[] tokens = line.Split(separators, System.StringSplitOptions.RemoveEmptyEntries);
+                                binder.CreateBinding(tokens[0], tokens[1]);
+                            }
                         }
                     }
                 }

--- a/Assets/WorldLocking.ASA/Scripts/SpacePinBinderFile.cs
+++ b/Assets/WorldLocking.ASA/Scripts/SpacePinBinderFile.cs
@@ -66,7 +66,7 @@ namespace Microsoft.MixedReality.WorldLocking.ASA
                 return false;
             }
             var bindings = binder.GetBindings();
-            using (StreamWriter writer = new StreamWriter(GetFullPath()))
+            using (StreamWriter writer = new StreamWriter(new FileStream(GetFullPath(), FileMode.Create)))
             {
                 writer.WriteLine($"{binderKey}{binder.Name}");
                 foreach (var binding in bindings)
@@ -95,7 +95,7 @@ namespace Microsoft.MixedReality.WorldLocking.ASA
                 Debug.LogError($"{name} can't find file {fullPath}");
                 return false;
             }
-            using (StreamReader reader = new StreamReader(GetFullPath()))
+            using (StreamReader reader = new StreamReader(new FileStream(GetFullPath(), FileMode.Open)))
             {
                 string line = reader.ReadLine();
                 while (line != null)

--- a/Assets/WorldLocking.Core/Scripts/OrienterThreeBody.cs
+++ b/Assets/WorldLocking.Core/Scripts/OrienterThreeBody.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Configuration;
 using UnityEngine;
 
 

--- a/Assets/WorldLocking.Core/Scripts/WorldLockingManager.cs
+++ b/Assets/WorldLocking.Core/Scripts/WorldLockingManager.cs
@@ -35,7 +35,7 @@ namespace Microsoft.MixedReality.WorldLocking.Core
         /// allowing quick visual verification of the version of World Locking Tools for Unity currently installed.
         /// It has no effect in code, but serves only as a label.
         /// </summary>
-        public static string Version => "1.5.3";
+        public static string Version => "1.5.4";
 
         /// <summary>
         /// The configuration settings may only be set as a block.

--- a/Assets/WorldLocking.Tools/Scripts/SimpleConsole.cs
+++ b/Assets/WorldLocking.Tools/Scripts/SimpleConsole.cs
@@ -116,22 +116,54 @@ namespace Microsoft.MixedReality.WorldLocking.Tools
         }
 
         /// <summary>
-        /// Cache the instance.
+        /// Cache this as the instance and open log writer.
+        /// </summary>
+        private void Awake()
+        {
+            SetupInstance(this);
+        }
+
+        /// <summary>
+        /// Cache this as the instance and open log writer.
         /// </summary>
         private void Start()
         {
-            Debug.Assert(_consoleInstance == null, "More than one Status component in the scene?");
-            _consoleInstance = this;
-            OpenLogWriter();
+            SetupInstance(this);
         }
 
-        private void OpenLogWriter()
+        /// <summary>
+        /// Cache the provided instance and open log writer.
+        /// </summary>
+        /// <param name="simpleConsole"></param>
+        private static void SetupInstance(SimpleConsole simpleConsole)
+        {
+            if (_consoleInstance != simpleConsole)
+            {
+                if (_consoleInstance != null)
+                {
+                    Debug.LogWarning($"More than one SimpleConsole in the scene? {simpleConsole.name} overriding {_consoleInstance.name}");
+                    _consoleInstance.CloseLogWriter();
+                }
+                _consoleInstance = simpleConsole;
+                if (_consoleInstance != null)
+                {
+                    _consoleInstance.OpenLogWriter();
+                }
+            }
+        }
+
+        private void CloseLogWriter()
         {
             if (logWriter != null)
             {
                 logWriter.Dispose();
                 logWriter = null;
             }
+        }
+
+        private void OpenLogWriter()
+        {
+            CloseLogWriter();
             if (!string.IsNullOrEmpty(LogFile))
             {
                 string path = Application.persistentDataPath;

--- a/Assets/WorldLocking.Tools/Scripts/SimpleConsole.cs
+++ b/Assets/WorldLocking.Tools/Scripts/SimpleConsole.cs
@@ -129,7 +129,7 @@ namespace Microsoft.MixedReality.WorldLocking.Tools
         {
             if (logWriter != null)
             {
-                logWriter.Close();
+                logWriter.Dispose();
                 logWriter = null;
             }
             if (!string.IsNullOrEmpty(LogFile))
@@ -137,7 +137,7 @@ namespace Microsoft.MixedReality.WorldLocking.Tools
                 string path = Application.persistentDataPath;
                 path = Path.Combine(path, LogFile);
 
-                logWriter = new StreamWriter(path);
+                logWriter = new StreamWriter(new FileStream(path, FileMode.Create));
             }
         }
 

--- a/UPM/asa_files/CHANGELOG.md
+++ b/UPM/asa_files/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [See release notes](https://github.com/microsoft/MixedReality-WorldLockingTools-Unity/releases)
 
+## 1.5.4 - Dependency on WLT 1.5.4.
+
 ## 1.5.3 - Remove dependency on tuple, and add MR Feature Tool support back to Unity 2018.4.
 
 ## 1.5.2 - Delay startup for Holographic Remoting.

--- a/UPM/asa_files/CHANGELOG.md
+++ b/UPM/asa_files/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 [See release notes](https://github.com/microsoft/MixedReality-WorldLockingTools-Unity/releases)
 
-## 1.5.4 - Dependency on WLT 1.5.4.
+## 1.5.4 - Fix timing issue with ASA anchors sometimes not created in time.
 
 ## 1.5.3 - Remove dependency on tuple, and add MR Feature Tool support back to Unity 2018.4.
 

--- a/UPM/asa_files/package.json
+++ b/UPM/asa_files/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.microsoft.mixedreality.wlt.asa",
   "displayName": "WLT-ASA",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "unity": "2020.3",
   "msftFeatureCategory": "World Locking Tools",
   "description": "World Locking Tools for Unity (WLT) + Azure Spatial Anchors (ASA)\n\nThis optional add-on to WLT leverages ASA to persist coordinate spaces across sessions and share them across devices.\nCross platform support includes HoloLens, Android, and iOS.",
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "com.microsoft.azure.spatial-anchors-sdk.core": "2.9.0",
-    "com.microsoft.mixedreality.worldlockingtools": "1.5.3"
+    "com.microsoft.mixedreality.worldlockingtools": "1.5.4"
   },
   "files": [
     "WorldLocking.ASA",

--- a/UPM/asa_samples_files/CHANGELOG.md
+++ b/UPM/asa_samples_files/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [See release notes](https://github.com/microsoft/MixedReality-WorldLockingTools-Unity/releases)
 
+## 1.5.4 - Dependency on WLT 1.5.4.
+
 ## 1.5.3 - Remove dependency on tuple, and add MR Feature Tool support back to Unity 2018.4.
 
 ## 1.5.2 - Delay startup for Holographic Remoting.

--- a/UPM/asa_samples_files/CHANGELOG.md
+++ b/UPM/asa_samples_files/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 [See release notes](https://github.com/microsoft/MixedReality-WorldLockingTools-Unity/releases)
 
-## 1.5.4 - Dependency on WLT 1.5.4.
+## 1.5.4 - Fix timing issue with ASA anchors sometimes not created in time.
 
 ## 1.5.3 - Remove dependency on tuple, and add MR Feature Tool support back to Unity 2018.4.
 

--- a/UPM/asa_samples_files/package.json
+++ b/UPM/asa_samples_files/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.microsoft.mixedreality.wlt.asa.samples",
   "displayName": "WLT-ASA Samples",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "unity": "2020.3",
   "msftFeatureCategory" : "World Locking Tools",
   "description": "Example scenes and scripts leveraging Azure Space Anchors (ASA) to persist World Locked coordinate spaces across sessions and share across devices.\n\nFurther samples available at\nhttps://microsoft.github.io/MixedReality-WorldLockingTools-Samples/README.html",
@@ -36,9 +36,9 @@
   "dependencies": {
     "com.microsoft.azure.spatial-anchors-sdk.core": "2.9.0",
     "com.microsoft.mixedreality.toolkit.foundation": "2.7.0",
-    "com.microsoft.mixedreality.wlt.asa": "1.5.3",
-    "com.microsoft.mixedreality.worldlockingtools": "1.5.3",
-    "com.microsoft.mixedreality.worldlockingsamples": "1.5.3"
+    "com.microsoft.mixedreality.wlt.asa": "1.5.4",
+    "com.microsoft.mixedreality.worldlockingtools": "1.5.4",
+    "com.microsoft.mixedreality.worldlockingsamples": "1.5.4"
   },
   "files": [
     "package.json.meta",

--- a/UPM/core_files/CHANGELOG.md
+++ b/UPM/core_files/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [See release notes](https://github.com/microsoft/MixedReality-WorldLockingTools-Unity/releases)
 
+## 1.5.4 - Backward compatibility for Unity 2018 .NET backend.
+
 ## 1.5.3 - Remove dependency on tuple, and add MR Feature Tool support back to Unity 2018.4.
 
 ## 1.5.2 - Delay startup for Holographic Remoting.

--- a/UPM/core_files/package.json
+++ b/UPM/core_files/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.microsoft.mixedreality.worldlockingtools",
   "displayName": "WLT Core",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "unity": "2018.4",
   "msftFeatureCategory" : "World Locking Tools",
   "description": "World Locking Tools for Unity (WLT)\n\nLock AR virtual space to physical space automatically and intuitively, without requiring application management of anchors.\nPreserve object relative layout, while remaining perceptually stationary in the physical world.",

--- a/UPM/samples_files/CHANGELOG.md
+++ b/UPM/samples_files/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [See release notes](https://github.com/microsoft/MixedReality-WorldLockingTools-Unity/releases)
 
+## 1.5.4 - Compatibility for Unity 2018 .NET backend.
+
 ## 1.5.3 - Remove dependency on tuple, and add MR Feature Tool support back to Unity 2018.4.
 
 ## 1.5.2 - Delay startup for Holographic Remoting.

--- a/UPM/samples_files/package.json
+++ b/UPM/samples_files/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.microsoft.mixedreality.worldlockingsamples",
   "displayName": "WLT Samples",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "unity": "2018.4",
   "msftFeatureCategory" : "World Locking Tools",
   "description": "Basic examples for World Locking Tools.\n\nFurther samples available at\nhttps://microsoft.github.io/MixedReality-WorldLockingTools-Samples/README.html",
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "com.microsoft.mixedreality.toolkit.foundation": "2.7.0",
-    "com.microsoft.mixedreality.worldlockingtools": "1.5.3"
+    "com.microsoft.mixedreality.worldlockingtools": "1.5.4"
   },
   "files": [
     "package.json.meta",


### PR DESCRIPTION
Fixes #217 

Also includes a 1-frame delay to workaround ASA anchors sometimes not being ready immediately after creation.