### PR TITLE
Avoid redundant session update on mobile.

### DIFF
--- a/Assets/WorldLocking.Core/Scripts/XR/AnchorManagerXR.cs
+++ b/Assets/WorldLocking.Core/Scripts/XR/AnchorManagerXR.cs
@@ -242,6 +242,7 @@ namespace Microsoft.MixedReality.WorldLocking.Core
             {
                 return false;
             }
+#if !UNITY_ANDROID && !UNITY_IOS
             if (sessionSubsystem != null)
             {
                 sessionSubsystem.Update(new XRSessionUpdateParams
@@ -250,6 +251,7 @@ namespace Microsoft.MixedReality.WorldLocking.Core
                     screenDimensions = new Vector2Int(Screen.width, Screen.height)
                 });
             }
+#endif // !UNITY_ANDROID && !UNITY_IOS            
             DebugLogExtra($"UpdateTrackables {Time.frameCount} XRAnchorSubsystem is {xrAnchorManager.running}");
             TrackableChanges<XRAnchor> changes = xrAnchorManager.GetChanges(Unity.Collections.Allocator.Temp);
             if (changes.isCreated && (changes.added.Length + changes.updated.Length + changes.removed.Length > 0))

--- a/Assets/WorldLocking.Core/Scripts/XR/AnchorManagerXR_2018.cs
+++ b/Assets/WorldLocking.Core/Scripts/XR/AnchorManagerXR_2018.cs
@@ -91,6 +91,7 @@ namespace Microsoft.MixedReality.WorldLocking.Core
 
         private static async Task<bool> CheckXRRunning()
         {
+#if WLT_XR_MANAGEMENT_PRESENT
             DebugLogSetup($"F={Time.frameCount} checking that XR is running.");
             // Wait for XR initialization before initializing the anchor subsystem to ensure that any pending Remoting connection has been established first.
             while (UnityEngine.XR.Management.XRGeneralSettings.Instance == null ||
@@ -104,6 +105,7 @@ namespace Microsoft.MixedReality.WorldLocking.Core
                 await Task.Yield();
             }
             DebugLogSetup($"F={Time.frameCount} XR is running.");
+#endif // WLT_XR_MANAGEMENT_PRESENT
             return true;
         }
 
@@ -231,6 +233,16 @@ namespace Microsoft.MixedReality.WorldLocking.Core
             {
                 return false;
             }
+#if !UNITY_ANDROID && !UNITY_IOS
+            if (sessionSubsystem != null)
+            {
+                sessionSubsystem.Update(new XRSessionUpdateParams
+                {
+                    screenOrientation = Screen.orientation,
+                    screenDimensions = new Vector2Int(Screen.width, Screen.height)
+                });
+            }
+#endif // !UNITY_ANDROID && !UNITY_IOS            
             TrackableChanges<XRReferencePoint> changes = xrReferencePointManager.GetChanges(Unity.Collections.Allocator.Temp);
             if (changes.isCreated && (changes.added.Length + changes.updated.Length + changes.removed.Length > 0))
             {


### PR DESCRIPTION
On mobile, MRTK quietly injects an ARSession, which updates the XRSessionSubsystem. On HoloLens it doesn't.

WLT calls XRSessionSubsystem.Update when anchor subsystem is XR SDK, but only on HoloLens.