### PR TITLE
Setup "AR Session" node for compatibility with MRTK.

### DIFF
--- a/Assets/WorldLocking.ASA.Examples/Scenes/PinTest.unity
+++ b/Assets/WorldLocking.ASA.Examples/Scenes/PinTest.unity
@@ -151,9 +151,56 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1607754546}
+  - {fileID: 135846989}
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &135846988
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 135846989}
+  - component: {fileID: 135846990}
+  m_Layer: 0
+  m_Name: AR Session
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &135846989
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 135846988}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 118694855}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &135846990
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 135846988}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3859a92a05d4f5d418cb6ca605290e74, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_AttemptUpdate: 1
+  m_MatchFrameRate: 1
+  m_TrackingMode: 2
 --- !u!1 &270376704
 GameObject:
   m_ObjectHideFlags: 0
@@ -691,6 +738,7 @@ MonoBehaviour:
       AutoSave: 0
     linkageSettings:
       useExisting: 0
+      applyAdjustment: 1
       AdjustmentFrame: {fileID: 118694855}
       CameraParent: {fileID: 1607754546}
     anchorSettings:
@@ -701,6 +749,7 @@ MonoBehaviour:
       MinNewAnchorDistance: 1
       MaxAnchorEdgeLength: 1.2
       MaxLocalAnchors: 0
+      NullSubsystemInEditor: 1
   diagnosticsSettings:
     settings:
       useDefaults: 1
@@ -2249,7 +2298,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1607754546}
-  - component: {fileID: 1607754549}
   - component: {fileID: 1607754548}
   - component: {fileID: 1607754547}
   m_Layer: 0
@@ -2300,21 +2348,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Camera: {fileID: 0}
---- !u!114 &1607754549
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1607754545}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3859a92a05d4f5d418cb6ca605290e74, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_AttemptUpdate: 1
-  m_MatchFrameRate: 1
-  m_TrackingMode: 2
 --- !u!1 &2147212412
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/WorldLocking.ASA.Examples/Scenes/PinTestSofa.unity
+++ b/Assets/WorldLocking.ASA.Examples/Scenes/PinTestSofa.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 705507994}
-  m_IndirectSpecularColor: {r: 0.18028378, g: 0.22571412, b: 0.30692285, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -246,9 +246,56 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1607754546}
+  - {fileID: 223020110}
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &223020109
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 223020110}
+  - component: {fileID: 223020111}
+  m_Layer: 0
+  m_Name: AR Session
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &223020110
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 223020109}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 118694855}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &223020111
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 223020109}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3859a92a05d4f5d418cb6ca605290e74, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_AttemptUpdate: 1
+  m_MatchFrameRate: 1
+  m_TrackingMode: 2
 --- !u!1 &245479088
 GameObject:
   m_ObjectHideFlags: 0
@@ -1071,16 +1118,18 @@ MonoBehaviour:
       AutoSave: 0
     linkageSettings:
       useExisting: 0
+      applyAdjustment: 1
       AdjustmentFrame: {fileID: 118694855}
       CameraParent: {fileID: 1607754546}
     anchorSettings:
       useDefaults: 0
       anchorSubsystem: 3
-      ARSessionSource: {fileID: 1607754545}
+      ARSessionSource: {fileID: 223020109}
       ARSessionOriginSource: {fileID: 1607754545}
       MinNewAnchorDistance: 1
       MaxAnchorEdgeLength: 1.2
       MaxLocalAnchors: 0
+      NullSubsystemInEditor: 1
   diagnosticsSettings:
     settings:
       useDefaults: 1
@@ -3200,7 +3249,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1607754546}
-  - component: {fileID: 1607754549}
   - component: {fileID: 1607754548}
   - component: {fileID: 1607754547}
   m_Layer: 0
@@ -3251,21 +3299,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Camera: {fileID: 0}
---- !u!114 &1607754549
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1607754545}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3859a92a05d4f5d418cb6ca605290e74, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_AttemptUpdate: 1
-  m_MatchFrameRate: 1
-  m_TrackingMode: 2
 --- !u!1 &1785474983
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
MRTK looks for a GameObject named "AR Session", and then looks for the ARSession component on that node. If it doesn't find the node by name, or doesn't find the component on it, it creates a new ARSession component and adds it to the scene.

This change allows MRTK to find the extant ARSession component so it won't create a redundant one. This can have very large performance ramifications, seen on Android Galaxy.