### PR TITLE
Update WorldLocking.ASA to use ASA SDK v2.11.0

### DIFF
--- a/Assets/WorldLocking.ASA/Microsoft.MixedReality.WorldLocking.ASA.asmdef
+++ b/Assets/WorldLocking.ASA/Microsoft.MixedReality.WorldLocking.ASA.asmdef
@@ -6,7 +6,8 @@
         "Microsoft.MixedReality.WorldLocking.Core",
         "Microsoft.MixedReality.WorldLocking.Tools",
         "AzureSpatialAnchors.SDK.Windows.Runtime",
-        "AzureSpatialAnchors.SDK.Android.Runtime"
+        "AzureSpatialAnchors.SDK.Android.Runtime",
+        "Unity.XR.ARFoundation"
     ],
     "includePlatforms": [
         "Android",

--- a/Assets/WorldLocking.ASA/Scripts/PublisherASA.cs
+++ b/Assets/WorldLocking.ASA/Scripts/PublisherASA.cs
@@ -18,7 +18,7 @@ using UnityEngine;
 #if WLT_ASA_INCLUDED
 using Microsoft.Azure.SpatialAnchors;
 using Microsoft.Azure.SpatialAnchors.Unity;
-using NativeAnchor = Microsoft.Azure.SpatialAnchors.Unity.ARFoundation.UnityARFoundationAnchorComponent;
+using UnityEngine.XR.ARFoundation;
 #endif // WLT_ASA_INCLUDED
 
 using Microsoft.MixedReality.WorldLocking.Core;
@@ -288,7 +288,7 @@ namespace Microsoft.MixedReality.WorldLocking.ASA
             /// <summary>
             /// Safe accessor for the NativeAnchor, may return null.
             /// </summary>
-            public NativeAnchor NativeAnchor
+            public ARAnchor NativeAnchor
             {
                 get
                 {


### PR DESCRIPTION
For Hololens2(UWP) build, Space Pin ASA restored to incorrect position on using ASA SDK older than v.2.11.0.

On updating ASA SDK to v.2.11.0, compile error has occurred.
The cause of this was NativeAnchor changed from UnityARFoundationAnchorComponent to ARAnchor by updating ASA SDK v2.11.0.