### PR TITLE
Add reference to ASA SDK iOS in WorldLocking.ASA

### DIFF
--- a/Assets/WorldLocking.ASA/Microsoft.MixedReality.WorldLocking.ASA.asmdef
+++ b/Assets/WorldLocking.ASA/Microsoft.MixedReality.WorldLocking.ASA.asmdef
@@ -6,7 +6,8 @@
         "Microsoft.MixedReality.WorldLocking.Core",
         "Microsoft.MixedReality.WorldLocking.Tools",
         "AzureSpatialAnchors.SDK.Windows.Runtime",
-        "AzureSpatialAnchors.SDK.Android.Runtime"
+        "AzureSpatialAnchors.SDK.Android.Runtime",
+        "AzureSpatialAnchors.SDK.iOS.Runtime"
     ],
     "includePlatforms": [
         "Android",


### PR DESCRIPTION
Fail to build WLT-ASA for iOS platform because a reference to AzureSpatialAnchors.SDK.iOS is missing.