### PR TITLE
Up ASA dependencies to ASA v2.11.0

### DIFF
--- a/UPM/asa_files/package.json
+++ b/UPM/asa_files/package.json
@@ -34,7 +34,7 @@
     "url": "https://github.com/microsoft/MixedReality-WorldLockingTools-Unity/issues"
   },
   "dependencies": {
-    "com.microsoft.azure.spatial-anchors-sdk.core": "2.9.0",
+    "com.microsoft.azure.spatial-anchors-sdk.core": "2.11.0",
     "com.microsoft.mixedreality.worldlockingtools": "1.5.6"
   },
   "files": [

--- a/UPM/asa_samples_files/package.json
+++ b/UPM/asa_samples_files/package.json
@@ -34,7 +34,7 @@
     "url": "https://github.com/microsoft/MixedReality-WorldLockingTools-Unity/issues"
   },
   "dependencies": {
-    "com.microsoft.azure.spatial-anchors-sdk.core": "2.9.0",
+    "com.microsoft.azure.spatial-anchors-sdk.core": "2.11.0",
     "com.microsoft.mixedreality.toolkit.foundation": "2.7.0",
     "com.microsoft.mixedreality.wlt.asa": "1.5.6",
     "com.microsoft.mixedreality.worldlockingtools": "1.5.6",


### PR DESCRIPTION
Earlier versions seem to have been broken by a Unity or OS update. See #240 