### PR TITLE
Raise creation point of underlying anchors

### DIFF
--- a/Assets/WorldLocking.ASA/Scripts/PublisherASA.cs
+++ b/Assets/WorldLocking.ASA/Scripts/PublisherASA.cs
@@ -1231,8 +1231,8 @@ namespace Microsoft.MixedReality.WorldLocking.ASA
                 + $" pa={WorldLockingManager.GetInstance().AnchorManager.AnchorFromSpongy.Inverse().Multiply(frozenPose).position.ToString("F3")}"
                 );
 
-#if WLT_ASA_SESSION_ORIGIN_WORKAROUND
-            // mafinc - workaround for bug in ASA NativeAnchor.
+#if WLT_ASA_V2_10_2_OR_OLDER && WLT_ASA_SESSION_ORIGIN_WORKAROUND
+            // mafinc - workaround for bug in ASA NativeAnchor. Not needed (and breaks things) for ASA v2.11 and later.
             peg.anchorHanger.transform.SetLocalPose(Pose.identity);
 #endif // WLT_ASA_SESSION_ORIGIN_WORKAROUND
 

--- a/Assets/WorldLocking.ASA/Scripts/SpacePinBinder.cs
+++ b/Assets/WorldLocking.ASA/Scripts/SpacePinBinder.cs
@@ -327,6 +327,7 @@ namespace Microsoft.MixedReality.WorldLocking.ASA
                     SpacePinASA spacePin = spacePins[idx];
 
                     Pose lockedPose = wltMgr.LockedFromFrozen.Multiply(pegAndProps.localPeg.GlobalPose);
+                    SimpleConsole.AddLine(ConsoleLow, $"Srch: {lockedPose.ToString("F3")}");
                     spacePin.SetLockedPose(lockedPose);
                     spacePin.SetLocalPeg(pegAndProps.localPeg);
                 }

--- a/Assets/WorldLocking.Core/Editor/WorldLockingContextEditor.cs
+++ b/Assets/WorldLocking.Core/Editor/WorldLockingContextEditor.cs
@@ -78,6 +78,8 @@ namespace Microsoft.MixedReality.WorldLocking.Core
                     {
                         AddProperty(mgrPath, "applyAdjustment");
 
+                        AddProperty(mgrPath, "NoPitchAndRoll");
+
                         AddProperty(mgrPath, "AdjustmentFrame");
 
                         AddProperty(mgrPath, "CameraParent");

--- a/Assets/WorldLocking.Core/Scripts/AnchorManager.cs
+++ b/Assets/WorldLocking.Core/Scripts/AnchorManager.cs
@@ -234,9 +234,8 @@ namespace Microsoft.MixedReality.WorldLocking.Core
             // 
             Pose spongyHead = headTracker.GetHeadPose();
 
-            // place new anchors 1m below head
+            // place new anchors at head
             Pose newSpongyAnchorPose = spongyHead;
-            newSpongyAnchorPose.position.y -= 1;
             newSpongyAnchorPose.rotation = Quaternion.identity;
 
             var activeAnchors = new List<AnchorPose>();

--- a/Assets/WorldLocking.Core/Scripts/LinkageSettings.cs
+++ b/Assets/WorldLocking.Core/Scripts/LinkageSettings.cs
@@ -42,6 +42,12 @@ namespace Microsoft.MixedReality.WorldLocking.Core
         private bool applyAdjustment;
 
         /// <summary>
+        /// Zero out pitch and roll from the FrozenWorldEngine correction.
+        /// </summary>
+        [Tooltip("Zero out pitch and roll from the FrozenWorldEngine correction.")]
+        public bool NoPitchAndRoll;
+
+        /// <summary>
         /// Apply world locking adjustment to the AdjustmentFrame.
         /// </summary>
         /// <remarks>
@@ -72,6 +78,7 @@ namespace Microsoft.MixedReality.WorldLocking.Core
         public void InitToDefaults()
         {
             UseExisting = false;
+            NoPitchAndRoll = false;
             ApplyAdjustment = true;
             AdjustmentFrame = null;
             CameraParent = null;

--- a/Assets/WorldLocking.Core/Scripts/WorldLockingManager.cs
+++ b/Assets/WorldLocking.Core/Scripts/WorldLockingManager.cs
@@ -151,6 +151,13 @@ namespace Microsoft.MixedReality.WorldLocking.Core
         /// </remarks>
         public bool ApplyAdjustment => shared.linkageSettings.ApplyAdjustment;
 
+        /// <summary>
+        /// Zero out pitch and roll from FrozenWorldEngine's computed correction.
+        /// </summary>
+        /// <remarks>
+        /// This does not affect pitch and roll from the AlignmentManager (SpacePins).
+        /// </remarks>
+        public bool NoPitchAndRoll => shared.linkageSettings.NoPitchAndRoll;
 
         /// <summary>
         /// Direct interface to the plugin. It is not generally necessary or desired to 
@@ -683,6 +690,10 @@ namespace Microsoft.MixedReality.WorldLocking.Core
             if (Enabled)
             {
                 Pose playspaceFromLocked = Plugin.GetAlignment();
+                if (NoPitchAndRoll)
+                {
+                    playspaceFromLocked.rotation = Quaternion.Euler(0f, playspaceFromLocked.rotation.eulerAngles.y, 0f); // Zero out X and Z rotation from frozen world engine
+                }
                 LockedFromPlayspace = playspaceFromLocked.Inverse();
 
                 SpongyFromCamera = Plugin.GetSpongyHead();

--- a/Assets/WorldLocking.Core/Scripts/WorldLockingManager.cs
+++ b/Assets/WorldLocking.Core/Scripts/WorldLockingManager.cs
@@ -35,7 +35,7 @@ namespace Microsoft.MixedReality.WorldLocking.Core
         /// allowing quick visual verification of the version of World Locking Tools for Unity currently installed.
         /// It has no effect in code, but serves only as a label.
         /// </summary>
-        public static string Version => "1.5.5";
+        public static string Version => "1.5.7";
 
         /// <summary>
         /// The configuration settings may only be set as a block.

--- a/Assets/WorldLocking.Tools/Scripts/AnchorGraphVisual.cs
+++ b/Assets/WorldLocking.Tools/Scripts/AnchorGraphVisual.cs
@@ -39,6 +39,23 @@ namespace Microsoft.MixedReality.WorldLocking.Tools
         [SerializeField]
         private Material connectingLine = null;
 
+        /// <summary>
+        /// Vertical distance to offset from actual anchors, to avoid visuals at eye level.
+        /// </summary>
+        /// <remarks>
+        /// Set this to zero to display visuals at actual anchor locations.
+        /// </remarks>
+        public float VerticalDisplacement { get { return verticalDisplacement; } set { verticalDisplacement = value; } }
+
+        /// <summary>
+        /// Vertical distance to offset from actual anchors, to avoid visuals at eye level.
+        /// </summary>
+        /// <remarks>
+        /// Set this to zero to display visuals at actual anchor locations.
+        /// </remarks>
+        [Tooltip("Vertical distance to offset from actual anchors, to avoid visuals at eye level.")]
+        [SerializeField]
+        private float verticalDisplacement = -1.0f;
         #endregion Public properties
 
         #region Internal properties
@@ -166,7 +183,7 @@ namespace Microsoft.MixedReality.WorldLocking.Tools
             var spongyCurrent = anchorManager.SpongyAnchors;
             spongyCurrent.Sort((x, y) => x.anchorId.CompareTo(y.anchorId));
 
-            SpongyVisualCreator spongyCreator = new SpongyVisualCreator(Prefab_SpongyAnchorViz, spongyWorldViz);
+            SpongyVisualCreator spongyCreator = new SpongyVisualCreator(Prefab_SpongyAnchorViz, spongyWorldViz, verticalDisplacement);
             ResourceMirror.Sync(
                 spongyCurrent,
                 spongyResources,
@@ -220,6 +237,8 @@ namespace Microsoft.MixedReality.WorldLocking.Tools
 
             /// The "frozen" coordinates here are ignoring the rest of the transform up the camera tree.
             Pose globalFromLocked = manager.ApplyAdjustment ? manager.FrozenFromLocked : manager.SpongyFromLocked;
+            /// Apply the vertical displacement through the globalFromLocked transform.
+            globalFromLocked.position = new Vector3(globalFromLocked.position.x, globalFromLocked.position.y + verticalDisplacement, globalFromLocked.position.z);
 
             var frozenCreator = new FrozenAnchorVisualCreator(Prefab_FrozenAnchorViz, frozenFragmentVizs, globalFromLocked);
             ResourceMirror.Sync(
@@ -443,6 +462,7 @@ namespace Microsoft.MixedReality.WorldLocking.Tools
         {
             private readonly SpongyAnchorVisual Prefab_SpongyAnchorVisual;
             private readonly FrameVisual spongyWorldVisual;
+            private readonly float verticalDisplacement;
 
             /// <summary>
             /// Constructor takes the prefab to construct the visual out of, and a FrameVisual
@@ -450,10 +470,11 @@ namespace Microsoft.MixedReality.WorldLocking.Tools
             /// </summary>
             /// <param name="prefab">Prefab to create the visual out of.</param>
             /// <param name="spongyWorldVisual">Parent of created visuals.</param>
-            public SpongyVisualCreator(SpongyAnchorVisual prefab, FrameVisual spongyWorldVisual)
+            public SpongyVisualCreator(SpongyAnchorVisual prefab, FrameVisual spongyWorldVisual, float verticalDisplacement)
             {
                 Prefab_SpongyAnchorVisual = prefab;
                 this.spongyWorldVisual = spongyWorldVisual;
+                this.verticalDisplacement = verticalDisplacement;
             }
 
             /// <summary>
@@ -466,7 +487,8 @@ namespace Microsoft.MixedReality.WorldLocking.Tools
             {
                 var spongyAnchorVisual = Prefab_SpongyAnchorVisual.Instantiate(
                     spongyWorldVisual,
-                    source.spongyAnchor);
+                    source.spongyAnchor,
+                    verticalDisplacement);
 
                 resource = new IdPair<AnchorId, SpongyAnchorVisual>()
                 {

--- a/Assets/WorldLocking.Tools/Scripts/SpongyAnchorVisual.cs
+++ b/Assets/WorldLocking.Tools/Scripts/SpongyAnchorVisual.cs
@@ -44,12 +44,17 @@ namespace Microsoft.MixedReality.WorldLocking.Tools
         private Color color;
 
         /// <summary>
+        /// Set in AnchorGraphVisual.
+        /// </summary>
+        private float verticalDisplacement = 0;
+
+        /// <summary>
         /// Create a visualizer for a spongy anchor.
         /// </summary>
         /// <param name="parent">Coordinate space to create the visualizer in</param>
         /// <param name="spongyAnchor">The spongyAnchor component assigned to some other object that this object is supposed to sync with</param>
         /// <returns></returns>
-        public SpongyAnchorVisual Instantiate(FrameVisual parent, SpongyAnchor spongyAnchor)
+        public SpongyAnchorVisual Instantiate(FrameVisual parent, SpongyAnchor spongyAnchor, float verticalDisplacement)
         {
             var res = Instantiate(this, parent.transform);
             res.name = spongyAnchor.name;
@@ -59,6 +64,7 @@ namespace Microsoft.MixedReality.WorldLocking.Tools
             }
             res.spongyAnchor = spongyAnchor;
             res.color = Color.gray;
+            res.verticalDisplacement = verticalDisplacement;
             return res;
         }
 
@@ -74,7 +80,9 @@ namespace Microsoft.MixedReality.WorldLocking.Tools
             // The SpongyFrame is adjusted by FrozeWorld every frame. This means that giving a transform M relative to the SpongyFrame,
             // as done here, will put the object _relative to the camera_ in the same place as setting M as the world transform
             // if SpongyFrame wasn't there, i.e. Unity World Space.
-            transform.SetLocalPose(spongyAnchor.SpongyPose);
+            Pose localPose = spongyAnchor.SpongyPose;
+            localPose.position = new Vector3(localPose.position.x, localPose.position.y + verticalDisplacement, localPose.position.z);
+            transform.SetLocalPose(localPose);
 
             if (!spongyAnchor.IsLocated)
                 color = Color.gray;

--- a/UPM/asa_files/CHANGELOG.md
+++ b/UPM/asa_files/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [See release notes](https://github.com/microsoft/MixedReality-WorldLockingTools-Unity/releases)
 
+## 1.5.7 - Increased anchor stabilization.
+
 ## 1.5.6 - Update to ASA v2.11.0.
 
 ## 1.5.4 - Fix timing issue with ASA anchors sometimes not created in time.

--- a/UPM/asa_files/package.json
+++ b/UPM/asa_files/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.microsoft.mixedreality.wlt.asa",
   "displayName": "WLT-ASA",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "unity": "2020.3",
   "msftFeatureCategory": "World Locking Tools",
   "description": "World Locking Tools for Unity (WLT) + Azure Spatial Anchors (ASA)\n\nThis optional add-on to WLT leverages ASA to persist coordinate spaces across sessions and share them across devices.\nCross platform support includes HoloLens, Android, and iOS.",
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "com.microsoft.azure.spatial-anchors-sdk.core": "2.11.0",
-    "com.microsoft.mixedreality.worldlockingtools": "1.5.6"
+    "com.microsoft.mixedreality.worldlockingtools": "1.5.7"
   },
   "files": [
     "WorldLocking.ASA",

--- a/UPM/asa_samples_files/CHANGELOG.md
+++ b/UPM/asa_samples_files/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [See release notes](https://github.com/microsoft/MixedReality-WorldLockingTools-Unity/releases)
 
+## 1.5.7 - Increased anchor stabilization.
+
 ## 1.5.6 - Update to ASA v2.11.0.
 
 ## 1.5.4 - Fix timing issue with ASA anchors sometimes not created in time.

--- a/UPM/asa_samples_files/package.json
+++ b/UPM/asa_samples_files/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.microsoft.mixedreality.wlt.asa.samples",
   "displayName": "WLT-ASA Samples",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "unity": "2020.3",
   "msftFeatureCategory" : "World Locking Tools",
   "description": "Example scenes and scripts leveraging Azure Space Anchors (ASA) to persist World Locked coordinate spaces across sessions and share across devices.\n\nFurther samples available at\nhttps://microsoft.github.io/MixedReality-WorldLockingTools-Samples/README.html",
@@ -36,9 +36,9 @@
   "dependencies": {
     "com.microsoft.azure.spatial-anchors-sdk.core": "2.11.0",
     "com.microsoft.mixedreality.toolkit.foundation": "2.7.0",
-    "com.microsoft.mixedreality.wlt.asa": "1.5.6",
-    "com.microsoft.mixedreality.worldlockingtools": "1.5.6",
-    "com.microsoft.mixedreality.worldlockingsamples": "1.5.6"
+    "com.microsoft.mixedreality.wlt.asa": "1.5.7",
+    "com.microsoft.mixedreality.worldlockingtools": "1.5.7",
+    "com.microsoft.mixedreality.worldlockingsamples": "1.5.7"
   },
   "files": [
     "package.json.meta",

--- a/UPM/core_files/CHANGELOG.md
+++ b/UPM/core_files/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [See release notes](https://github.com/microsoft/MixedReality-WorldLockingTools-Unity/releases)
 
+## 1.5.7 - Increased anchor stabilization.
+
 ## 1.5.6 - Update to ASA v2.11.0.
 
 ## 1.5.4 - Backward compatibility for Unity 2018 .NET backend.

--- a/UPM/core_files/package.json
+++ b/UPM/core_files/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.microsoft.mixedreality.worldlockingtools",
   "displayName": "WLT Core",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "unity": "2018.4",
   "msftFeatureCategory" : "World Locking Tools",
   "description": "World Locking Tools for Unity (WLT)\n\nLock AR virtual space to physical space automatically and intuitively, without requiring application management of anchors.\nPreserve object relative layout, while remaining perceptually stationary in the physical world.",

--- a/UPM/samples_files/CHANGELOG.md
+++ b/UPM/samples_files/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [See release notes](https://github.com/microsoft/MixedReality-WorldLockingTools-Unity/releases)
 
+## 1.5.7 - Increased anchor stabilization.
+
 ## 1.5.6 - Update to ASA v2.11.0.
 
 ## 1.5.4 - Compatibility for Unity 2018 .NET backend.

--- a/UPM/samples_files/package.json
+++ b/UPM/samples_files/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.microsoft.mixedreality.worldlockingsamples",
   "displayName": "WLT Samples",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "unity": "2018.4",
   "msftFeatureCategory" : "World Locking Tools",
   "description": "Basic examples for World Locking Tools.\n\nFurther samples available at\nhttps://microsoft.github.io/MixedReality-WorldLockingTools-Samples/README.html",
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "com.microsoft.mixedreality.toolkit.foundation": "2.7.0",
-    "com.microsoft.mixedreality.worldlockingtools": "1.5.6"
+    "com.microsoft.mixedreality.worldlockingtools": "1.5.7"
   },
   "files": [
     "package.json.meta",


### PR DESCRIPTION
* Improve anchor stability by creating them at camera position, rather than the traditional 1 meter down.
* Add vertical offset parameter on the AnchorGraphVisual to optionally display anchors lower or higher than their actual position, to allow avoidance of anchor visuals at eye level.
* Fix a compatibility issue with ASA v2.11, removing a workaround for an ASA issue needed for earlier versions, but harmful for v2.11.