### PR TITLE
Log warning in PluginNoop instead of Error to avoid breaking tests

### DIFF
--- a/Assets/WorldLocking.Engine/PluginNoop.cs
+++ b/Assets/WorldLocking.Engine/PluginNoop.cs
@@ -38,7 +38,7 @@ namespace Microsoft.MixedReality.WorldLocking.Core
 
         public PluginNoop()
         {
-            Debug.LogError("Creating PluginNoop, is this intentional?");
+            Debug.LogWarning("Creating PluginNoop, is this intentional?");
             checkError();
             metrics = new MetricsAccessor();
         }


### PR DESCRIPTION
It seems more suitable to log this as warning, since the back end has already been selected (perhaps on purpose), so this may not be an error at all.

Additionally, logging errors will cause Unity scene tests to fail, as error logs are treated as test failure. This can be ignored by updating the test, but it could require updating every test (e.g. our scene contains the world locking tools and the noop backend immediately constructs when running in CI on a Linux Unity environment).