### PR TITLE
Persistence changes in MROpenXR

### DIFF
--- a/Assets/WorldLocking.Core/Microsoft.MixedReality.WorldLocking.Core.asmdef
+++ b/Assets/WorldLocking.Core/Microsoft.MixedReality.WorldLocking.Core.asmdef
@@ -54,6 +54,11 @@
             "name": "com.unity.xr.openxr",
             "expression": "",
             "define": "WLT_XR_OPENXR_PRESENT"
+        },
+        {
+            "name": "com.microsoft.mixedreality.openxr",
+            "expression": "1.4",
+            "define": "WLT_MICROSOFT_OPENXR_1_4_OR_NEWER"
         }
     ],
     "noEngineReferences": false

--- a/Assets/WorldLocking.Core/Scripts/ARF/AnchorManagerARF_OpenXR.cs
+++ b/Assets/WorldLocking.Core/Scripts/ARF/AnchorManagerARF_OpenXR.cs
@@ -19,6 +19,10 @@
 #define WLT_XR_PERSISTENCE
 #endif // WLT_XR_PERSISTENCE
 
+#if WLT_MICROSOFT_OPENXR_1_4_OR_NEWER
+#define WLT_USE_ARMANAGER_EXTENSIONS
+#endif // WLT_MICROSOFT_OPENXR_1_4_OR_NEWER
+
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -30,6 +34,9 @@ using UnityEngine.XR.ARFoundation;
 #if WLT_XR_PERSISTENCE
 using Microsoft.MixedReality.OpenXR;
 using UnityEngine.XR.ARSubsystems;
+#if WLT_USE_ARMANAGER_EXTENSIONS
+using Microsoft.MixedReality.OpenXR.ARFoundation;
+#endif // WLT_USE_ARMANAGER_EXTENSIONS
 #endif // WLT_XR_PERSISTENCE
 
 
@@ -67,8 +74,11 @@ namespace Microsoft.MixedReality.WorldLocking.Core
             if (openXRAnchorStore == null)
             {
                 DebugLogExtra($"Getting new OpenXR XRAnchorStore.");
-                //                openXRAnchorStore = await arAnchorManager.LoadAnchorStoreAsync();
+#if WLT_USE_ARMANAGER_EXTENSIONS
+                openXRAnchorStore = await arAnchorManager.LoadAnchorStoreAsync();
+#else // WLT_USE_ARMANAGER_EXTENSIONS
                 openXRAnchorStore = await XRAnchorStore.LoadAsync(arAnchorManager.subsystem);
+#endif // WLT_USE_ARMANAGER_EXTENSIONS
             }
             openXRPersistence = openXRAnchorStore != null;
             return openXRAnchorStore;
@@ -110,7 +120,7 @@ namespace Microsoft.MixedReality.WorldLocking.Core
         }
 #endif
 
-        protected async Task SaveAnchorsOpenXR(List<SpongyAnchorWithId> spongyAnchors)
+                protected async Task SaveAnchorsOpenXR(List<SpongyAnchorWithId> spongyAnchors)
         {
             Debug.Assert(openXRPersistence, "Attempting to save via OpenXR when unsupported.");
 #if WLT_XR_PERSISTENCE

--- a/Assets/WorldLocking.Core/Scripts/ARF/AnchorManagerARF_OpenXR.cs
+++ b/Assets/WorldLocking.Core/Scripts/ARF/AnchorManagerARF_OpenXR.cs
@@ -120,7 +120,7 @@ namespace Microsoft.MixedReality.WorldLocking.Core
         }
 #endif
 
-                protected async Task SaveAnchorsOpenXR(List<SpongyAnchorWithId> spongyAnchors)
+        protected async Task SaveAnchorsOpenXR(List<SpongyAnchorWithId> spongyAnchors)
         {
             Debug.Assert(openXRPersistence, "Attempting to save via OpenXR when unsupported.");
 #if WLT_XR_PERSISTENCE

--- a/Assets/WorldLocking.Core/Scripts/WorldLockingManager.cs
+++ b/Assets/WorldLocking.Core/Scripts/WorldLockingManager.cs
@@ -34,8 +34,10 @@ namespace Microsoft.MixedReality.WorldLocking.Core
         /// The version of this release. This will be displayed in the WorldLockingContext component in the Unity Inspector,
         /// allowing quick visual verification of the version of World Locking Tools for Unity currently installed.
         /// It has no effect in code, but serves only as a label.
+        /// A "_dev" suffix means it's the main branch under current development (between releases). When released,
+        /// the _dev suffix is removed. For example, 1.5.9_dev is released as 1.5.9.
         /// </summary>
-        public static string Version => "1.5.9";
+        public static string Version => "1.5.10_dev";
 
         /// <summary>
         /// The configuration settings may only be set as a block.

--- a/Assets/WorldLocking.Core/Scripts/XR/AnchorManagerXR_OpenXR.cs
+++ b/Assets/WorldLocking.Core/Scripts/XR/AnchorManagerXR_OpenXR.cs
@@ -9,6 +9,10 @@
 #define WLT_XR_PERSISTENCE
 #endif // WLT_XR_PERSISTENCE
 
+#if WLT_MICROSOFT_OPENXR_1_4_OR_NEWER
+#define WLT_USE_ARSUBSYSTEM_EXTENSIONS
+#endif // WLT_MICROSOFT_OPENXR_1_4_OR_NEWER
+
 //#define WLT_EXTRA_LOGGING
 
 #if WLT_DISABLE_LOGGING
@@ -22,8 +26,10 @@ using UnityEngine;
 using UnityEngine.XR;
 
 #if WLT_XR_PERSISTENCE
-//using Microsoft.MixedReality.ARSubsystems;
 using Microsoft.MixedReality.OpenXR;
+#if WLT_USE_ARSUBSYSTEM_EXTENSIONS
+using Microsoft.MixedReality.OpenXR.ARSubsystems;
+#endif // WLT_USE_ARSUBSYSTEM_EXTENSIONS
 #endif // WLT_XR_PERSISTENCE
 
 using UnityEngine.SpatialTracking;
@@ -47,15 +53,18 @@ namespace Microsoft.MixedReality.WorldLocking.Core
             if (openXRAnchorStore == null)
             {
                 DebugLogExtra($"Getting new OpenXR XRAnchorStore.");
-                //                openXRAnchorStore = await xrAnchorManager.LoadAnchorStoreAsync();
+#if WLT_USE_ARSUBSYSTEM_EXTENSIONS
+                openXRAnchorStore = await xrAnchorManager.LoadAnchorStoreAsync();
+#else // WLT_USE_ARSUBSYSTEM_EXTENSIONS
                 openXRAnchorStore = await XRAnchorStore.LoadAsync(xrAnchorManager);
+#endif // WLT_USE_ARSUBSYSTEM_EXTENSIONS
             }
             openXRPersistence = openXRAnchorStore != null;
             return openXRAnchorStore;
         }
 #endif // WLT_XR_PERSISTENCE
 
-        protected async Task SaveAnchorsOpenXR(List<SpongyAnchorWithId> spongyAnchors)
+                protected async Task SaveAnchorsOpenXR(List<SpongyAnchorWithId> spongyAnchors)
         {
             Debug.Assert(openXRPersistence, "Attempting to save via OpenXR when unsupported.");
 #if WLT_XR_PERSISTENCE

--- a/Assets/WorldLocking.Core/Scripts/XR/AnchorManagerXR_OpenXR.cs
+++ b/Assets/WorldLocking.Core/Scripts/XR/AnchorManagerXR_OpenXR.cs
@@ -64,7 +64,7 @@ namespace Microsoft.MixedReality.WorldLocking.Core
         }
 #endif // WLT_XR_PERSISTENCE
 
-                protected async Task SaveAnchorsOpenXR(List<SpongyAnchorWithId> spongyAnchors)
+        protected async Task SaveAnchorsOpenXR(List<SpongyAnchorWithId> spongyAnchors)
         {
             Debug.Assert(openXRPersistence, "Attempting to save via OpenXR when unsupported.");
 #if WLT_XR_PERSISTENCE


### PR DESCRIPTION
Adopt new persistence APIs for MROpenXR when version is greater or equal to 1.4.0.

Specifically, replace deprecated XRAnchorStore.LoadAsync() with ARAnchorManager and XRAnchorSubsystem extensions LoadAnchorStoreAsync().

Also bumps version from 1.5.9 (last release) to 1.5.10_dev.